### PR TITLE
Expose correct rotation values

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -6,23 +6,21 @@ TSharedPtr<FJsonObject> UFRM_Library::getActorJSON(AActor* Actor) {
 
 	TSharedPtr<FJsonObject> JLibrary = MakeShared<FJsonObject>();
 
-	long double ZActor = Actor->GetActorRotation().Quaternion().Z;
-
 	long double primaryX = Actor->GetActorLocation().X;
 	long double primaryY = Actor->GetActorLocation().Y;
 	long double primaryZ = Actor->GetActorLocation().Z;
 
+	// UE rotations range from -180 to 180 with zero as "forward" and negative values "left".
+	// In Satisfactory this results in a rotation of zero being due east.
+	// FRM will normalise this to a range of 0 <= x < 360 with zero as due north.
+	long double rotation = Actor->GetActorRotation().Yaw;
+	rotation += 450;
+	rotation = fmod(rotation, 360);
+
 	JLibrary->Values.Add("x", MakeShared<FJsonValueNumber>(primaryX));
 	JLibrary->Values.Add("y", MakeShared<FJsonValueNumber>(primaryY));
 	JLibrary->Values.Add("z", MakeShared<FJsonValueNumber>(primaryZ));
-
-	//Because East is what Epic decided to call heading 0, with a -180 to 180 spread.	
-	ZActor = ZActor + 450;
-	if (ZActor > 360) {
-		ZActor = ZActor - 360;
-	}
-
-	JLibrary->Values.Add("rotation", MakeShared<FJsonValueNumber>(ZActor));
+	JLibrary->Values.Add("rotation", MakeShared<FJsonValueNumber>(rotation));
 		
 	return JLibrary;
 


### PR DESCRIPTION
The `rotation` field of most elements on most endpoints currently show a non-degree non-radian number between 89 and 91 with inconsistent steps between angles. This change should restore the intended behaviour: a value with 0 as north, 90 as east, etc.