### PR TITLE
refactor: move group inventory to additional method

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Player.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Player.cpp
@@ -57,48 +57,17 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Player::getDoggo(UObject* WorldContext) {
 		fgcheck(ModSubsystem);
 
 		FString DisplayName;
+
+		// get doggo inventory and display name
 		TArray<FInventoryStack> InventoryStacks;
-
 		ModSubsystem->GetDoggoInfo_BIE(Doggo, DisplayName, InventoryStacks);
-		TMap<TSubclassOf<UFGItemDescriptor>, float> StorageInventory;
-		TArray<TSharedPtr<FJsonValue>> JDoggoStorageArray;
-
-		TArray<TSubclassOf<UFGItemDescriptor>> ClassNames;
-		UFGBlueprintFunctionLibrary::GetAllDescriptorsSorted(WorldContext->GetWorld(), ClassNames);
-
-		for (FInventoryStack Inventory : InventoryStacks) {
-
-			auto ItemClass = Inventory.Item.GetItemClass();
-			auto Amount = Inventory.NumItems;
-
-			if (StorageInventory.Contains(ItemClass)) {
-				StorageInventory.Add(ItemClass) = Amount + StorageInventory.FindRef(ItemClass);
-			}
-			else {
-				StorageInventory.Add(ItemClass) = Amount;
-			};
-
-		};
-
-		for (TSubclassOf<UFGItemDescriptor> ClassName : ClassNames) {
-
-			if (StorageInventory.Contains(ClassName))
-			{
-				TSharedPtr<FJsonObject> JDoggoStorage = MakeShared<FJsonObject>();
-
-				JDoggoStorage->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(ClassName).ToString()));
-				JDoggoStorage->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(ClassName->GetClass())));
-				JDoggoStorage->Values.Add("Amount", MakeShared<FJsonValueNumber>(StorageInventory.FindRef(ClassName)));
-
-				JDoggoStorageArray.Add(MakeShared<FJsonValueObject>(JDoggoStorage));
-			};
-		};
+		TMap<TSubclassOf<UFGItemDescriptor>, int32> DoggoInventory = UFRM_Library::GetGroupedInventoryItems(InventoryStacks);
 
 		JDoggo->Values.Add("ID", MakeShared<FJsonValueNumber>(Index));
 		JDoggo->Values.Add("Name", MakeShared<FJsonValueString>(DisplayName));
 		JDoggo->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Doggo->GetClass())));
 		JDoggo->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Doggo)));
-		JDoggo->Values.Add("Inventory", MakeShared<FJsonValueArray>(JDoggoStorageArray));
+		JDoggo->Values.Add("Inventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(DoggoInventory)));
 		JDoggo->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(Doggo, DisplayName, TEXT("Lizard Doggo"))));
 
 		JDoggoArray.Add(MakeShared<FJsonValueObject>(JDoggo));

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
@@ -23,6 +23,8 @@ public:
 	static TSharedPtr<FJsonObject> getActorFactoryCompXYZ(UFGFactoryConnectionComponent* BeltPipe);
 	static TSharedPtr<FJsonObject> getActorPipeXYZ(UFGPipeConnectionComponent* BeltPipe);
 	static TSharedPtr<FJsonObject> getActorFeaturesJSON(AActor* Actor, FString DisplayName, FString TypeName);
+	static TMap<TSubclassOf<UFGItemDescriptor>, int32> GetGroupedInventoryItems(const TArray<FInventoryStack>& InventoryStacks);
+	static TArray<TSharedPtr<FJsonValue>> GetInventoryJSON(const TMap<TSubclassOf<UFGItemDescriptor>, int32>& Items);
 	static FString APItoJSON(TArray<TSharedPtr<FJsonValue>> JSONArray, UObject* WorldContext);
 	static bool IsIntInRange(int32 Number, int32 LowerBound, int32 UpperBound);
 


### PR DESCRIPTION
i moved the loop to group the inventory items and build the json to two extra methods
every time where the inventory will be returned in the api is an own for loop with the same stuff, that is now moved to methods
and it would be easier to improve these functions or extend something, without change it everywhere

i don't know if i do everything right, it's one of my first c++ code, so please check if thats correct/good
getDoggo was the first place where i tested the methods, and it seems to work 🎉

if everything is fine i would replace it for everything else

just for your information:

i changed `UKismetSystemLibrary::GetClassDisplayName(ClassName->GetClass()))` to `UKismetSystemLibrary::GetClassDisplayName(Item.Key))` because the `ClassName->getClass()` always returned `BlueprintGeneratedClass` and the `Item.Key` way returns something like `Desc_ModularFrameHeavy_C`, this is more helpful than the first one