### PR TITLE
refactor: refactor all inventory jsons to GetGroupedInventoryItems and GetInventoryJSON

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -114,13 +114,38 @@ bool UFRM_Library::IsIntInRange(int32 Number, int32 LowerBound, int32 UpperBound
 	return bIsMoreThanLowerBound && bIsLessThanUpperBound;
 }
 
+TMap<TSubclassOf<UFGItemDescriptor>, int32> UFRM_Library::GetGroupedInventoryItems(const UFGInventoryComponent* Inventory)
+{
+	TArray<FInventoryStack> InventoryStacks;
+
+	Inventory->GetInventoryStacks(InventoryStacks);
+
+	return GetGroupedInventoryItems(InventoryStacks);
+}
+
+void UFRM_Library::GetGroupedInventoryItems(const UFGInventoryComponent* Inventory, TMap<TSubclassOf<UFGItemDescriptor>, int32>& InventoryItems)
+{
+	TArray<FInventoryStack> InventoryStacks;
+
+	Inventory->GetInventoryStacks(InventoryStacks);
+
+	GetGroupedInventoryItems(InventoryStacks, InventoryItems);
+}
+
 TMap<TSubclassOf<UFGItemDescriptor>, int32> UFRM_Library::GetGroupedInventoryItems(const TArray<FInventoryStack>& InventoryStacks)
 {
 	TMap<TSubclassOf<UFGItemDescriptor>, int32> InventoryItems;
 
+	GetGroupedInventoryItems(InventoryStacks, InventoryItems);
+
+	return InventoryItems;
+}
+
+void UFRM_Library::GetGroupedInventoryItems(const TArray<FInventoryStack>& InventoryStacks, TMap<TSubclassOf<UFGItemDescriptor>, int32>& InventoryItems)
+{
 	for (FInventoryStack Inventory : InventoryStacks) {
 		auto ItemClass = Inventory.Item.GetItemClass();
-		auto Amount = Inventory.NumItems;
+		const auto Amount = Inventory.NumItems;
 
 		if (InventoryItems.Contains(ItemClass)) {
 			InventoryItems.Add(ItemClass) = Amount + InventoryItems.FindRef(ItemClass);
@@ -129,8 +154,6 @@ TMap<TSubclassOf<UFGItemDescriptor>, int32> UFRM_Library::GetGroupedInventoryIte
 			InventoryItems.Add(ItemClass) = Amount;
 		}
 	}
-
-	return InventoryItems;
 }
 
 TArray<TSharedPtr<FJsonValue>> UFRM_Library::GetInventoryJSON(const TMap<TSubclassOf<UFGItemDescriptor>, int32>& Items)

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -203,39 +203,8 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 				case ETrainPlatformDockingStatus::ETPDS_WaitingToStart				:	StatusString = TEXT("Waiting To Start");
 			}
 
-			TSharedPtr<FJsonObject> JStorage = MakeShared<FJsonObject>();
-			TArray<FInventoryStack> InventoryStacks;
-			TrainPlatformCargo->GetInventory()->GetInventoryStacks(InventoryStacks);
-
-			TMap<TSubclassOf<UFGItemDescriptor>, int32> Storage;
-
-			for (FInventoryStack Inventory : InventoryStacks) {
-
-				auto ItemClass = Inventory.Item.GetItemClass();
-				auto Amount = Inventory.NumItems;
-
-				if (Storage.Contains(ItemClass)) {
-					Storage.Add(ItemClass) = Amount + Storage.FindRef(ItemClass);
-				}
-				else {
-					Storage.Add(ItemClass) = Amount;
-				};
-
-			};
-
-			TArray<TSharedPtr<FJsonValue>> JInventoryArray;
-
-			for (const TPair< TSubclassOf<UFGItemDescriptor>, int32> StorageStack : Storage) {
-
-				TSharedPtr<FJsonObject> JInventory = MakeShared<FJsonObject>();
-
-				JInventory->Values.Add("Name", MakeShared<FJsonValueString>((StorageStack.Key.GetDefaultObject()->mDisplayName).ToString()));
-				JInventory->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(StorageStack.Key->GetClass())));
-				JInventory->Values.Add("Amount", MakeShared<FJsonValueNumber>(StorageStack.Value));
-
-				JInventoryArray.Add(MakeShared<FJsonValueObject>(JInventory));
-
-			};
+			// get train platorm inventory
+			TMap<TSubclassOf<UFGItemDescriptor>, int32> TrainPlatformInventory = UFRM_Library::GetGroupedInventoryItems(TrainPlatformCargo->GetInventory());
 
 			JTrainPlatform->Values.Add("Name", MakeShared<FJsonValueString>(TrainPlatformCargo->mDisplayName.ToString()));
 			JTrainPlatform->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(TrainPlatformCargo->GetClass())));
@@ -247,7 +216,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 			JTrainPlatform->Values.Add("LoadingMode", MakeShared<FJsonValueString>(LoadMode));
 			JTrainPlatform->Values.Add("LoadingStatus", MakeShared<FJsonValueString>(LoadingStatus));
 			JTrainPlatform->Values.Add("DockingStatus", MakeShared<FJsonValueString>(StatusString));
-			JTrainPlatform->Values.Add("Inventory", MakeShared<FJsonValueArray>(JInventoryArray));
+			JTrainPlatform->Values.Add("Inventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(TrainPlatformInventory)));
 
 			JTrainPlatformArray.Add(MakeShared<FJsonValueObject>(JTrainPlatform));
 		}

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Vehicles.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Vehicles.cpp
@@ -45,78 +45,13 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getTruckStation(UObject* WorldCont
 		}
 		else if (Form == EProductionStatus::IS_ERROR) {
 			FormString = "Error";
-		};
+		}
 
-		TArray<TSubclassOf<UFGItemDescriptor>> ClassNames;
-		UFGBlueprintFunctionLibrary::GetAllDescriptorsSorted(WorldContext->GetWorld(), ClassNames);
+		// get fuel inventory
+		TMap<TSubclassOf<UFGItemDescriptor>, int32> FuelInventory = UFRM_Library::GetGroupedInventoryItems(TruckStation->GetFuelInventory());
 
-		TArray<FInventoryStack> FuelInventoryStacks;
-		UFGInventoryComponent* StationFuelInventory = TruckStation->GetFuelInventory();
-		TMap<TSubclassOf<UFGItemDescriptor>, float> FuelPetroInventory;
-		StationFuelInventory->GetInventoryStacks(FuelInventoryStacks);
-		for (FInventoryStack FuelInventory : FuelInventoryStacks) {
-
-			auto ItemClass = FuelInventory.Item.GetItemClass();
-			auto Amount = FuelInventory.NumItems;
-
-			if (FuelPetroInventory.Contains(ItemClass)) {
-				FuelPetroInventory.Add(ItemClass) = Amount + FuelPetroInventory.FindRef(ItemClass);
-			}
-			else {
-				FuelPetroInventory.Add(ItemClass) = Amount;
-			};
-
-		};
-
-		TArray<TSharedPtr<FJsonValue>> JTruckStationFuelArray;
-
-		for (TSubclassOf<UFGItemDescriptor> ClassName : ClassNames) {
-
-			if (FuelPetroInventory.Contains(ClassName))
-			{
-				TSharedPtr<FJsonObject> JTruckStationStorage = MakeShared<FJsonObject>();
-
-				JTruckStationStorage->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(ClassName).ToString()));
-				JTruckStationStorage->Values.Add("ClassName", MakeShared<FJsonValueString>(ClassName.GetDefaultObject()->GetClass()->GetName()));
-				JTruckStationStorage->Values.Add("Amount", MakeShared<FJsonValueNumber>(FuelPetroInventory.FindRef(ClassName)));
-
-				JTruckStationFuelArray.Add(MakeShared<FJsonValueObject>(JTruckStationStorage));
-			};
-		};
-
-		TArray<FInventoryStack> InventoryStacks;
-		UFGInventoryComponent* StationInventory = TruckStation->GetInventory();
-		TMap<TSubclassOf<UFGItemDescriptor>, float> StorageInventory;
-		StationInventory->GetInventoryStacks(InventoryStacks);
-		for (FInventoryStack Inventory : InventoryStacks) {
-
-			auto ItemClass = Inventory.Item.GetItemClass();
-			auto Amount = Inventory.NumItems;
-
-			if (StorageInventory.Contains(ItemClass)) {
-				StorageInventory.Add(ItemClass) = Amount + StorageInventory.FindRef(ItemClass);
-			}
-			else {
-				StorageInventory.Add(ItemClass) = Amount;
-			};
-
-		};
-
-		TArray<TSharedPtr<FJsonValue>> JTruckStationStorageArray;
-
-		for (TSubclassOf<UFGItemDescriptor> ClassName : ClassNames) {
-
-			if (StorageInventory.Contains(ClassName))
-			{
-				TSharedPtr<FJsonObject> JTruckStationStorage = MakeShared<FJsonObject>();
-
-				JTruckStationStorage->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(ClassName).ToString()));
-				JTruckStationStorage->Values.Add("ClassName", MakeShared<FJsonValueString>(ClassName.GetDefaultObject()->GetClass()->GetName()));
-				JTruckStationStorage->Values.Add("Amount", MakeShared<FJsonValueNumber>(StorageInventory.FindRef(ClassName)));
-
-				JTruckStationStorageArray.Add(MakeShared<FJsonValueObject>(JTruckStationStorage));
-			};
-		};
+		// get inventory
+		TMap<TSubclassOf<UFGItemDescriptor>, int32> Inventory = UFRM_Library::GetGroupedInventoryItems(TruckStation->GetInventory());
 
 		JTruckStation->Values.Add("Name", MakeShared<FJsonValueString>(TruckStation->mDisplayName.ToString()));
 		JTruckStation->Values.Add("ClassName", MakeShared<FJsonValueString>(TruckStation->GetClass()->GetName()));
@@ -127,12 +62,12 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getTruckStation(UObject* WorldCont
 		JTruckStation->Values.Add("MaxTransferRate", MakeShared<FJsonValueNumber>(TruckStation->GetMaximumStackTransferRate()));
 		JTruckStation->Values.Add("StationStatus", MakeShared<FJsonValueString>(FormString));
 		JTruckStation->Values.Add("FuelRate", MakeShared<FJsonValueNumber>(TruckStation->GetVehicleFuelConsumptionRate()));
-		JTruckStation->Values.Add("Storage", MakeShared<FJsonValueArray>(JTruckStationStorageArray));
-		JTruckStation->Values.Add("Inventory", MakeShared<FJsonValueArray>(JTruckStationStorageArray));
+		JTruckStation->Values.Add("Inventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(Inventory)));
+		JTruckStation->Values.Add("FuelInventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(FuelInventory)));
 		JTruckStation->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(TruckStation, TruckStation->mDisplayName.ToString(), "Truck Station")));
 
 		JTruckStationArray.Add(MakeShared<FJsonValueObject>(JTruckStation));
-	};
+	}
 
 	return JTruckStationArray;
 };
@@ -154,43 +89,12 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getVehicles(UObject* WorldContext,
 			UFGWheeledVehicleMovementComponent* VehicleMovement = WheeledVehicle->GetVehicleMovementComponent();
 			AFGWheeledVehicleInfo* VehicleInfo = WheeledVehicle->GetInfo();
 
-			TArray<TSubclassOf<UFGItemDescriptor>> ClassNames;
-			UFGBlueprintFunctionLibrary::GetAllDescriptorsSorted(WorldContext->GetWorld(), ClassNames);
-
-			TArray<FInventoryStack> FuelInventoryStacks;
+			// get vehicle fuel inventory
 			UFGInventoryComponent* VehicleFuelInventory = WheeledVehicle->GetFuelInventory();
-			TMap<TSubclassOf<UFGItemDescriptor>, float> FuelPetroInventory;
-			TArray<TSharedPtr<FJsonValue>> JVehicleFuelArray;
+			TArray<TSharedPtr<FJsonValue>> FuelInventory;
 
 			if (IsValid(VehicleFuelInventory)) {
-				VehicleFuelInventory->GetInventoryStacks(FuelInventoryStacks);
-				for (FInventoryStack FuelInventory : FuelInventoryStacks) {
-
-					auto ItemClass = FuelInventory.Item.GetItemClass();
-					auto Amount = FuelInventory.NumItems;
-
-					if (FuelPetroInventory.Contains(ItemClass)) {
-						FuelPetroInventory.Add(ItemClass) = Amount + FuelPetroInventory.FindRef(ItemClass);
-					}
-					else {
-						FuelPetroInventory.Add(ItemClass) = Amount;
-					};
-
-				};
-
-				for (TSubclassOf<UFGItemDescriptor> ClassName : ClassNames) {
-
-					if (FuelPetroInventory.Contains(ClassName))
-					{
-						TSharedPtr<FJsonObject> JVehicleFuel = MakeShared<FJsonObject>();
-
-						JVehicleFuel->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(ClassName).ToString()));
-						JVehicleFuel->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(ClassName->GetClass())));
-						JVehicleFuel->Values.Add("Amount", MakeShared<FJsonValueNumber>(FuelPetroInventory.FindRef(ClassName)));
-
-						JVehicleFuelArray.Add(MakeShared<FJsonValueObject>(JVehicleFuel));
-					};
-				};
+				FuelInventory = UFRM_Library::GetInventoryJSON(UFRM_Library::GetGroupedInventoryItems(VehicleFuelInventory));
 			}
 			else {
 				TSharedPtr<FJsonObject> JVehicleFuel = MakeShared<FJsonObject>();
@@ -199,42 +103,15 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getVehicles(UObject* WorldContext,
 				JVehicleFuel->Values.Add("ClassName", MakeShared<FJsonValueString>("Desc_None"));
 				JVehicleFuel->Values.Add("Amount", MakeShared<FJsonValueNumber>(0));
 
-				JVehicleFuelArray.Add(MakeShared<FJsonValueObject>(JVehicleFuel));
-			};
+				FuelInventory.Add(MakeShared<FJsonValueObject>(JVehicleFuel));
+			}
 
-			TArray<FInventoryStack> InventoryStacks;
+			// get vehicle inventory
 			UFGInventoryComponent* VehicleInventory = WheeledVehicle->GetStorageInventory();
-			TMap<TSubclassOf<UFGItemDescriptor>, float> StorageInventory;
-			TArray<TSharedPtr<FJsonValue>> JVehicleStorageArray;
+			TArray<TSharedPtr<FJsonValue>> Inventory;
+
 			if (IsValid(VehicleInventory)) {
-				VehicleInventory->GetInventoryStacks(InventoryStacks);
-				for (FInventoryStack Inventory : InventoryStacks) {
-
-					auto ItemClass = Inventory.Item.GetItemClass();
-					auto Amount = Inventory.NumItems;
-
-					if (StorageInventory.Contains(ItemClass)) {
-						StorageInventory.Add(ItemClass) = Amount + StorageInventory.FindRef(ItemClass);
-					}
-					else {
-						StorageInventory.Add(ItemClass) = Amount;
-					};
-
-				};
-
-				for (TSubclassOf<UFGItemDescriptor> ClassName : ClassNames) {
-
-					if (StorageInventory.Contains(ClassName))
-					{
-						TSharedPtr<FJsonObject> JVehicleStorage = MakeShared<FJsonObject>();
-
-						JVehicleStorage->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(ClassName).ToString()));
-						JVehicleStorage->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(ClassName->GetClass())));
-						JVehicleStorage->Values.Add("Amount", MakeShared<FJsonValueNumber>(StorageInventory.FindRef(ClassName)));
-
-						JVehicleStorageArray.Add(MakeShared<FJsonValueObject>(JVehicleStorage));
-					};
-				};
+				Inventory = UFRM_Library::GetInventoryJSON(UFRM_Library::GetGroupedInventoryItems(VehicleInventory));
 			} 
 			else {
 				TSharedPtr<FJsonObject> JVehicleStorage = MakeShared<FJsonObject>();
@@ -243,9 +120,10 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getVehicles(UObject* WorldContext,
 				JVehicleStorage->Values.Add("ClassName", MakeShared<FJsonValueString>("Desc_None"));
 				JVehicleStorage->Values.Add("Amount", MakeShared<FJsonValueNumber>(0));
 
-				JVehicleStorageArray.Add(MakeShared<FJsonValueObject>(JVehicleStorage));
+				Inventory.Add(MakeShared<FJsonValueObject>(JVehicleStorage));
 			};
 
+			// get vehicle status
 			FString FormString = "Unknown";
 
 			EVehicleStatus Form = VehicleInfo->GetVehicleStatus();
@@ -282,8 +160,8 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getVehicles(UObject* WorldContext,
 			JVehicle->Values.Add("Airborne", MakeShared<FJsonValueBoolean>(VehicleMovement->IsInAir()));
 			JVehicle->Values.Add("FollowingPath", MakeShared<FJsonValueBoolean>(WheeledVehicle->IsFollowingAPath()));
 			JVehicle->Values.Add("Autopilot", MakeShared<FJsonValueBoolean>(WheeledVehicle->IsSelfDriving()));
-			JVehicle->Values.Add("Storage", MakeShared<FJsonValueArray>(JVehicleStorageArray));
-			JVehicle->Values.Add("Fuel", MakeShared<FJsonValueArray>(JVehicleFuelArray));
+			JVehicle->Values.Add("Inventory", MakeShared<FJsonValueArray>(Inventory));
+			JVehicle->Values.Add("FuelInventory", MakeShared<FJsonValueArray>(FuelInventory));
 			JVehicle->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(Vehicle, Vehicle->mDisplayName.ToString(), Vehicle->mDisplayName.ToString())));
 
 			JVehicleArray.Add(MakeShared<FJsonValueObject>(JVehicle));

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
@@ -23,7 +23,10 @@ public:
 	static TSharedPtr<FJsonObject> getActorFactoryCompXYZ(UFGFactoryConnectionComponent* BeltPipe);
 	static TSharedPtr<FJsonObject> getActorPipeXYZ(UFGPipeConnectionComponent* BeltPipe);
 	static TSharedPtr<FJsonObject> getActorFeaturesJSON(AActor* Actor, FString DisplayName, FString TypeName);
+	static TMap<TSubclassOf<UFGItemDescriptor>, int32> GetGroupedInventoryItems(const UFGInventoryComponent* Inventory);
 	static TMap<TSubclassOf<UFGItemDescriptor>, int32> GetGroupedInventoryItems(const TArray<FInventoryStack>& InventoryStacks);
+	static void GetGroupedInventoryItems(const TArray<FInventoryStack>& InventoryStacks, TMap<TSubclassOf<UFGItemDescriptor>, int32>& InventoryItems);
+	static void GetGroupedInventoryItems(const UFGInventoryComponent* Inventory, TMap<TSubclassOf<UFGItemDescriptor>, int32>& InventoryItems);
 	static TArray<TSharedPtr<FJsonValue>> GetInventoryJSON(const TMap<TSubclassOf<UFGItemDescriptor>, int32>& Items);
 	static FString APItoJSON(TArray<TSharedPtr<FJsonValue>> JSONArray, UObject* WorldContext);
 	static bool IsIntInRange(int32 Number, int32 LowerBound, int32 UpperBound);


### PR DESCRIPTION
i refactored the inventory stuff to the GetGroupedInventoryItems & GetInventoryJSON methods

- getDrones: add missing FuelInventory
- getTruckStation: renamed Storage to FuelInventory and it returns now the Fuel Inventory (more consistent to other endpoints)
- getVehicles: renamed Storage to Inventory and Fuel to FuelInventory (more consistent to other endpoints)

i tested everything and it looks good, but please check it again
i don't touched the getSpaceElevator endpoint because i think you are working on it for #91?