### PR TITLE
FEATURE: normalize power info. Add /getResourceSinkBuilding

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Drones.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Drones.cpp
@@ -121,6 +121,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Drones::getDroneStation(UObject* WorldContex
 		JDroneStation->Values.Add("ActiveFuel", MakeShared<FJsonValueObject>(JActiveFuel));
 		JDroneStation->Values.Add("FuelInfo", MakeShared<FJsonValueArray>(JFuelInfoArray));
 		JDroneStation->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(DroneStation, DroneStation->mDisplayName.ToString(), "Drone Station")));
+		JDroneStation->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(DroneStation->GetPowerInfo())));
 
 		JDroneStationArray.Add(MakeShared<FJsonValueObject>(JDroneStation));
 	};

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -245,3 +245,26 @@ TSharedPtr<FJsonValue> ConvertStringToFJsonValue(const FString& JsonString)
 	// Handle error: return nullptr or some default value
 	return nullptr;
 }
+
+TSharedPtr<FJsonObject> UFRM_Library::getPowerConsumptionJSON(UFGPowerInfoComponent* PowerInfo) {
+	return UFRM_Library::getPowerConsumptionJSON(PowerInfo, 0);
+}
+
+TSharedPtr<FJsonObject> UFRM_Library::getPowerConsumptionJSON(UFGPowerInfoComponent* PowerInfo, float additionalPowerConsumed) {
+
+	UFGPowerCircuit* PowerCircuit = PowerInfo->GetPowerCircuit();
+	TSharedPtr<FJsonObject> JCircuit = MakeShared<FJsonObject>();
+	int32 CircuitGroupID = -1;
+	int32 CircuitID = -1;
+	float PowerConsumed = additionalPowerConsumed;
+
+	if (IsValid(PowerCircuit)) {
+		CircuitGroupID = PowerCircuit->GetCircuitGroupID();
+		CircuitID = PowerCircuit->GetCircuitID();
+		PowerConsumed = PowerInfo->GetActualConsumption() + additionalPowerConsumed;
+	}
+	JCircuit->Values.Add("CircuitGroupID", MakeShared<FJsonValueNumber>(CircuitGroupID));
+	JCircuit->Values.Add("CircuitID", MakeShared<FJsonValueNumber>(CircuitID));
+	JCircuit->Values.Add("PowerConsumed", MakeShared<FJsonValueNumber>(PowerConsumed));
+	return JCircuit;
+};

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -291,20 +291,15 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 			
 		}
 
-		float CircuitID = TrainStation->GetStation()->GetPowerInfo()->GetActualConsumption();
-		//float PowerConsumption = TrainStation->GetStation()->GetPowerInfo()->GetActualConsumption();
-
 		JTrainStation->Values.Add("Name", MakeShared<FJsonValueString>(TrainStation->GetStationName().ToString()));
 		JTrainStation->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(RailStation->GetClass())));
 		JTrainStation->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(TrainStation)));
-		JTrainStation->Values.Add("PowerConsumption", MakeShared<FJsonValueNumber>(PowerConsumption));
 		JTrainStation->Values.Add("TransferRate", MakeShared<FJsonValueNumber>(TransferRate));
 		JTrainStation->Values.Add("InflowRate", MakeShared<FJsonValueNumber>(InFlowRate));
 		JTrainStation->Values.Add("OutflowRate", MakeShared<FJsonValueNumber>(OutFlowRate));
 		JTrainStation->Values.Add("CargoInventory", MakeShared<FJsonValueArray>(JTrainPlatformArray));
-		JTrainStation->Values.Add("CircuitID", MakeShared<FJsonValueNumber>(CircuitID));
-		JTrainStation->Values.Add("PowerConsumption", MakeShared<FJsonValueNumber>(PowerConsumption));
 		JTrainStation->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(TrainStation, TrainStation->GetStationName().ToString(), TEXT("Train Station"))));
+		JTrainStation->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(TrainStation->GetStation()->GetPowerInfo(), PowerConsumption)));
 
 		JTrainStationArray.Add(MakeShared<FJsonValueObject>(JTrainStation));
 	};

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Vehicles.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Vehicles.cpp
@@ -65,6 +65,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getTruckStation(UObject* WorldCont
 		JTruckStation->Values.Add("Inventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(Inventory)));
 		JTruckStation->Values.Add("FuelInventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(FuelInventory)));
 		JTruckStation->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(TruckStation, TruckStation->mDisplayName.ToString(), "Truck Station")));
+		JTruckStation->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(TruckStation->GetPowerInfo())));
 
 		JTruckStationArray.Add(MakeShared<FJsonValueObject>(JTruckStation));
 	}

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -473,6 +473,7 @@ void AFicsitRemoteMonitoring::InitAPIRegistry()
 	RegisterEndpoint("getResourceGeyser", true, true, this->Get(GetWorld()), FName("getResourceGeyser"));
 	RegisterEndpoint("getResourceNode", true, true, this->Get(GetWorld()), FName("getResourceNode"));
 	RegisterEndpoint("getResourceSink", true, false, this->Get(GetWorld()), FName("getResourceSink"));
+    RegisterEndpoint("getResourceSinkBuilding", true, false, this->Get(GetWorld()), FName("getResourceSinkBuilding"));
 	RegisterEndpoint("getResourceWell", true, true, this->Get(GetWorld()), FName("getResourceWell"));
 	RegisterEndpoint("getSchematics", true, true, this->Get(GetWorld()), FName("getSchematics"));
 	RegisterEndpoint("getSinkList", true, true, this->Get(GetWorld()), FName("getSinkList"));

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Factory.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Factory.h
@@ -16,6 +16,7 @@
 #include "Buildables/FGBuildableManufacturer.h"
 #include "Buildables/FGBuildableManufacturerVariablePower.h"
 #include "Buildables/FGBuildableResourceExtractor.h"
+#include "Buildables/FGBuildableResourceSink.h"
 #include "Buildables/FGBuildableSpaceElevator.h"
 #include "Buildables/FGBuildableRadarTower.h"
 #include "FGScannableSubsystem.h"
@@ -55,6 +56,7 @@ public:
 	static TArray<TSharedPtr<FJsonValue>> getWorldInv(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getDropPod(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getResourceExtractor(UObject* WorldContext);
+	static TArray<TSharedPtr<FJsonValue>> getResourceSinkBuilding(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getPipes(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getModList(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getResourceNode(UObject* WorldContext, UClass* ResourceActor);

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
@@ -43,4 +43,6 @@ public:
 	}
 
 	static TSharedPtr<FJsonValue> ConvertStringToFJsonValue(const FString& JsonString);
+	static TSharedPtr<FJsonObject> getPowerConsumptionJSON(UFGPowerInfoComponent* powerInfo);
+	static TSharedPtr<FJsonObject> getPowerConsumptionJSON(UFGPowerInfoComponent* powerInfo, float modifier);
 };

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -404,6 +404,11 @@ public:
 	}
 
 	UFUNCTION()
+	TArray<UBlueprintJsonValue*> getResourceSinkBuilding(UObject* WorldContext) {
+		return UBlueprintJsonValue::FromJsonArray(UFRM_Factory::getResourceSinkBuilding(WorldContext));
+	}
+
+	UFUNCTION()
 	TArray<UBlueprintJsonValue*> getResourceWell(UObject* WorldContext) {		
 		return UBlueprintJsonValue::FromJsonArray(UFRM_Factory::getResourceNode(WorldContext, AFGResourceNode::StaticClass()));
 	}


### PR DESCRIPTION
Normalize PowerInfo object for many buildings, that contains:

`CircuitID`
`CircuitGroupID`
`PowerConsumed`

Also adds a `/getResourceSinkBuilding` endpoint that gives `location` and `PowerInfo` for all sinks.

This also removes random redundant `CircuitID` references on many of the objects.

Closes #98