### PR TITLE
Add train power info

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -251,17 +251,18 @@ TSharedPtr<FJsonObject> UFRM_Library::getPowerConsumptionJSON(UFGPowerInfoCompon
 }
 
 TSharedPtr<FJsonObject> UFRM_Library::getPowerConsumptionJSON(UFGPowerInfoComponent* PowerInfo, float additionalPowerConsumed) {
-
-	UFGPowerCircuit* PowerCircuit = PowerInfo->GetPowerCircuit();
 	TSharedPtr<FJsonObject> JCircuit = MakeShared<FJsonObject>();
 	int32 CircuitGroupID = -1;
 	int32 CircuitID = -1;
 	float PowerConsumed = additionalPowerConsumed;
 
-	if (IsValid(PowerCircuit)) {
-		CircuitGroupID = PowerCircuit->GetCircuitGroupID();
-		CircuitID = PowerCircuit->GetCircuitID();
-		PowerConsumed = PowerInfo->GetActualConsumption() + additionalPowerConsumed;
+	if (IsValid(PowerInfo)) {
+		UFGPowerCircuit* PowerCircuit = PowerInfo->GetPowerCircuit();
+		if (IsValid(PowerCircuit)) {
+			CircuitGroupID = PowerCircuit->GetCircuitGroupID();
+			CircuitID = PowerCircuit->GetCircuitID();
+			PowerConsumed = PowerInfo->GetActualConsumption() + additionalPowerConsumed;
+		}
 	}
 	JCircuit->Values.Add("CircuitGroupID", MakeShared<FJsonValueNumber>(CircuitGroupID));
 	JCircuit->Values.Add("CircuitID", MakeShared<FJsonValueNumber>(CircuitID));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -35,6 +35,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrains(UObject* WorldContext) {
 		TArray<TSharedPtr<FJsonValue>> JRailcarsArray;
 		TSharedPtr<FJsonObject> TrainLocation;
 
+		UFGPowerInfoComponent* PowerInfo = NULL;
 		if (IsValid(MultiUnitMaster)) {
 
 			AFGRailroadTimeTable* TimeTable = Train->GetTimeTable();
@@ -65,6 +66,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrains(UObject* WorldContext) {
 
 			ForwardSpeed = LocomotiveMovement->GetForwardSpeed();
 			ThrottlePercent = LocomotiveMovement->GetThrottle() * 100;
+			PowerInfo = Train->GetMultipleUnitMaster()->GetPowerInfo();
 			
 		} else {
 
@@ -131,6 +133,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrains(UObject* WorldContext) {
 		JTrain->Values.Add("TimeTable", MakeShared<FJsonValueArray>(JTimetableArray));
 		JTrain->Values.Add("Vehicles", MakeShared<FJsonValueArray>(JRailcarsArray));
 		JTrain->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(Train, Train->GetTrainName().ToString(), "Train")));
+		JTrain->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(PowerInfo)));
 
 		JTrainsArray.Add(MakeShared<FJsonValueObject>(JTrain));
 


### PR DESCRIPTION
Adds PowerInfo metrics for trains

Check for valid power info before parsing. Return default nil powerinfo if it cannot be found.