### PR TITLE
add session info endpoint

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
@@ -766,3 +766,17 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPipes(UObject* WorldContext) {
 
 	return JPipeArray;
 };
+
+
+TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getSessionInfo(UObject* WorldContext) {
+
+	TSharedPtr<FJsonObject> JSessionInfo = MakeShared<FJsonObject>();
+	auto gameState = WorldContext->GetWorld()->GetGameState<AFGGameState>();
+	FString SessionName = gameState->GetSessionName();
+	JSessionInfo->Values.Add("SessionName", MakeShared<FJsonValueString>(SessionName));
+
+	TArray<TSharedPtr<FJsonValue>> JSessionInfoArray;
+	JSessionInfoArray.Add(MakeShared<FJsonValueObject>(JSessionInfo));
+
+	return JSessionInfoArray;
+}

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -542,6 +542,7 @@ void AFicsitRemoteMonitoring::InitAPIRegistry()
 	RegisterEndpoint("getResourceSink", true, false, this->Get(GetWorld()), FName("getResourceSink"));
     RegisterEndpoint("getResourceSinkBuilding", true, false, this->Get(GetWorld()), FName("getResourceSinkBuilding"));
 	RegisterEndpoint("getResourceWell", true, true, this->Get(GetWorld()), FName("getResourceWell"));
+    RegisterEndpoint("getSessionInfo", true, true, true, this->Get(GetWorld()), FName("getSessionInfo"));
 	RegisterEndpoint("getSchematics", true, true, this->Get(GetWorld()), FName("getSchematics"));
 	RegisterEndpoint("getSinkList", true, true, this->Get(GetWorld()), FName("getSinkList"));
 	RegisterEndpoint("getSmelter", false, false, this->Get(GetWorld()), FName("getSmelter"));

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Factory.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Factory.h
@@ -10,6 +10,7 @@
 #include "Buildables/FGBuildablePipeline.h"
 #include "FGPipeConnectionComponent.h"
 #include "FGFactoryConnectionComponent.h"
+#include "FGGameState.h"
 #include "Buildables/FGBuildableFactory.h"
 #include "Buildables/FGBuildableHubTerminal.h"
 #include "Buildables/FGBuildableTradingPost.h"
@@ -63,6 +64,7 @@ public:
 	static TArray<TSharedPtr<FJsonValue>> getRadarTower(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getSpaceElevator(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getCloudInv(UObject* WorldContext);
+	static TArray<TSharedPtr<FJsonValue>> getSessionInfo(UObject* WorldContext);
 
 	friend class AFGBuildableConveyorBase;
 	friend class AFGBuildableTradingPost;

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -448,6 +448,11 @@ public:
 	}
 
 	UFUNCTION()
+	TArray<UBlueprintJsonValue*> getSessionInfo(UObject* WorldContext) {
+		return UBlueprintJsonValue::FromJsonArray(UFRM_Factory::getSessionInfo(WorldContext));
+	}
+
+	UFUNCTION()
 	TArray<UBlueprintJsonValue*> getSpaceElevator(UObject* WorldContext) {		
 		return UBlueprintJsonValue::FromJsonArray(UFRM_Factory::getSpaceElevator(WorldContext));
 	}


### PR DESCRIPTION
Adds `/getSessionInfo` to get current session name.

Returns `{"SessionName":"the current game session name"}`

Closes #100 