### PR TITLE
fix: StopWebSocketServer will now close the websocket completely #117

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -291,18 +291,14 @@ void AFicsitRemoteMonitoring::StartWebSocketServer()
 
 }
 
-void AFicsitRemoteMonitoring::AddRequestHeaders(uWS::HttpResponse<false>* res, bool bIncludeContentType)
+void AFicsitRemoteMonitoring::AddResponseHeaders(uWS::HttpResponse<false>* res, bool bIncludeContentType)
 {
-    // set headers for all responses
-    // disable cache to prevent any cache issues
     res
         ->writeHeader("Access-Control-Allow-Origin", "*")
-        ->writeHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0")
         // uWebSockets does not automatically handle the closing of HTTP connections.
         // Therefore, we instruct the client to close the connection by setting the "Connection" header to "close"
         // instead of using "keep-alive" (default).
-        ->writeHeader("Connection", "close")
-        ->writeHeader("Pragma", "no-cache");
+        ->writeHeader("Connection", "close");
 
     if (bIncludeContentType) res->writeHeader("Content-Type", "application/json");
 }
@@ -454,7 +450,7 @@ void AFicsitRemoteMonitoring::HandleGetRequest(uWS::HttpResponse<false>* res, uW
 
             res->writeHeader("Content-Type", TCHAR_TO_UTF8(*ContentType));
             res->writeHeader("Content-Length", contentLength.c_str());
-            AddRequestHeaders(res, false);
+            AddResponseHeaders(res, false);
             res->write(std::string_view((char*)BinaryContent.GetData(), BinaryContent.Num()));
             res->end();
         }
@@ -467,7 +463,7 @@ void AFicsitRemoteMonitoring::HandleGetRequest(uWS::HttpResponse<false>* res, uW
             UE_LOG(LogHttpServer, Log, TEXT("File Found Returning: %s"), *FilePath);
 
             res->writeHeader("Content-Type", TCHAR_TO_UTF8(*ContentType));
-            AddRequestHeaders(res, false);
+            AddResponseHeaders(res, false);
             res->end(TCHAR_TO_UTF8(*FileContent));
         }
     }
@@ -475,7 +471,7 @@ void AFicsitRemoteMonitoring::HandleGetRequest(uWS::HttpResponse<false>* res, uW
     if (!FileLoaded) {
         UE_LOG(LogHttpServer, Error, TEXT("Failed to load file: %s"), *FilePath);
         res->writeStatus("500");
-        AddRequestHeaders(res, true);
+        AddResponseHeaders(res, true);
         res->end("Internal Server Error");
     }
 }
@@ -488,14 +484,14 @@ void AFicsitRemoteMonitoring::HandleApiRequest(UObject* World, uWS::HttpResponse
 
     if (bSuccess) {
         UE_LOGFMT(LogHttpServer, Log, "API Found Returning: {Endpoint}", Endpoint);
-        AddRequestHeaders(res, true);
+        AddResponseHeaders(res, true);
         res->end(TCHAR_TO_UTF8(*OutJson));
     }
     else
     {
         UE_LOGFMT(LogHttpServer, Log, "API Not Found: {Endpoint}", Endpoint);
         res->writeStatus("404 Not Found");
-        AddRequestHeaders(res, true);
+        AddResponseHeaders(res, true);
         res->end(TCHAR_TO_UTF8(*OutJson));
     }
 

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -182,7 +182,7 @@ void AFicsitRemoteMonitoring::StartWebSocketServer()
                     res->writeStatus("418 I'm a teapot");
                     res->writeHeader("Access-Control-Allow-Methods", "GET, POST");
                     res->writeHeader("Access-Control-Allow-Headers", "Content-Type");
-                    AddRequestHeaders(res, false);
+                    AddResponseHeaders(res, false);
 
                     res->end(TCHAR_TO_UTF8(*noCoffee));
                 });
@@ -681,14 +681,16 @@ FCallEndpointResponse AFicsitRemoteMonitoring::CallEndpoint(UObject* WorldContex
 	bSuccess = false;
     TArray<UBlueprintJsonValue*> JsonArray = TArray<UBlueprintJsonValue*>{};
 
+    Response.JsonValues = JsonArray;
+
     // socket listener is closed, so we skip the request to prevent any further error/crash
-    if (!SocketListener) return JsonArray;
+    if (!SocketListener) return Response;
 
     for (FAPIEndpoint& EndpointInfo : APIEndpoints)
     {
         // again, maybe SocketListener was killed while we are looping through the api endpoints?
         // i don't know, but it's better to be safe than to risk a game crash
-        if (!SocketListener) return JsonArray;
+        if (!SocketListener) return Response;
         
         if (EndpointInfo.APIName == InEndpoint)
         {

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -120,6 +120,8 @@ private:
 
 	TFuture<void> WebServer;
 
+	bool JSONDebugMode;
+	
 	friend class UFGPowerCircuitGroup;
 
 public:

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -177,6 +177,8 @@ public:
 
 	TMap<FString, TSet<uWS::WebSocket<false, true, FWebSocketUserData>*>> EndpointSubscribers;
 
+	TSet<uWS::WebSocket<false, true, FWebSocketUserData>*> ConnectedClients; 
+
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ficsit Remote Monitoring")
 	void InitSerialDevice();
 
@@ -188,7 +190,7 @@ public:
 	void StartWebSocketServer();
 	void StopWebSocketServer();
 
-    TArray<FClientInfo> ConnectedClients;
+    // TArray<FClientInfo> ConnectedClients;
 
     void OnClientDisconnected(uWS::WebSocket<false, true, FWebSocketUserData>* ws, int code, std::string_view message);
     void OnMessageReceived(uWS::WebSocket<false, true, FWebSocketUserData>* ws, std::string_view message, uWS::OpCode opCode);

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -199,7 +199,7 @@ public:
 	void PushUpdatedData();
 
 	void HandleGetRequest(uWS::HttpResponse<false>* res, uWS::HttpRequest* req, FString FilePath);
-	void AddRequestHeaders(uWS::HttpResponse<false>* res, bool bIncludeContentType);
+	void AddResponseHeaders(uWS::HttpResponse<false>* res, bool bIncludeContentType);
 
 	UPROPERTY()
 	TArray<FString> Flavor_Battery;

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -190,8 +190,6 @@ public:
 	void StartWebSocketServer();
 	void StopWebSocketServer();
 
-    // TArray<FClientInfo> ConnectedClients;
-
     void OnClientDisconnected(uWS::WebSocket<false, true, FWebSocketUserData>* ws, int code, std::string_view message);
     void OnMessageReceived(uWS::WebSocket<false, true, FWebSocketUserData>* ws, std::string_view message, uWS::OpCode opCode);
 	void ProcessClientRequest(uWS::WebSocket<false, true, FWebSocketUserData>* ws, const TSharedPtr<FJsonObject>& JsonRequest);

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -199,6 +199,7 @@ public:
 	void PushUpdatedData();
 
 	void HandleGetRequest(uWS::HttpResponse<false>* res, uWS::HttpRequest* req, FString FilePath);
+	void AddRequestHeaders(uWS::HttpResponse<false>* res, bool bIncludeContentType);
 
 	UPROPERTY()
 	TArray<FString> Flavor_Battery;


### PR DESCRIPTION
it's a fix for #117 🎉
only took 14 hours to find that out 😄

the uWS server does not close correctly, causing the first WebSocket server to continue listening for requests and leading to game crashes due to a null AFicsitRemoteMonitoring object
i now call `us_listen_socket_close` to prevent new connections and close all connected WebSocket clients in StopWebSocketServer to terminate the uWS loop completley

Adding the 'Connection: close' header prevents keep-alive after an HTTP request
uWebSockets can't close these connections, the client must close them, with 'Connection: close,' the connection will close automatically after the response is sent