### PR TITLE
Fix #126 - Avoid null dereference on Linux

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -167,7 +167,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 		UFGTrainPlatformConnection* TrainPlatformConnection = StationConnection->GetConnectedTo();
 		AFGBuildableTrainPlatform* TrainPlatform = nullptr;
 		
-		if (TrainPlatformConnection && TrainPlatformConnection->IsValidLowLevel())
+		if (TrainPlatformConnection)
 		{
 			 TrainPlatform = TrainPlatformConnection->GetPlatformOwner();
 		}
@@ -201,7 +201,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 				UFGTrainPlatformConnection* TrainPlatformConnectionBuffer = TrainPlatform->GetConnectionInOppositeDirection(TrainPlatformConnection);
 				TrainPlatformConnection = TrainPlatformConnectionBuffer->GetConnectedTo();
 
-				if (TrainPlatformConnection && TrainPlatformConnection->IsValidLowLevel())
+				if (TrainPlatformConnection)
 				{
 					TrainPlatform = TrainPlatformConnection->GetPlatformOwner();
 				} else

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -167,7 +167,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 		UFGTrainPlatformConnection* TrainPlatformConnection = StationConnection->GetConnectedTo();
 		AFGBuildableTrainPlatform* TrainPlatform = nullptr;
 		
-		if (TrainPlatformConnection || TrainPlatformConnection->IsValidLowLevel())
+		if (TrainPlatformConnection && TrainPlatformConnection->IsValidLowLevel())
 		{
 			 TrainPlatform = TrainPlatformConnection->GetPlatformOwner();
 		}
@@ -201,7 +201,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 				UFGTrainPlatformConnection* TrainPlatformConnectionBuffer = TrainPlatform->GetConnectionInOppositeDirection(TrainPlatformConnection);
 				TrainPlatformConnection = TrainPlatformConnectionBuffer->GetConnectedTo();
 
-				if (TrainPlatformConnection || TrainPlatformConnection->IsValidLowLevel())
+				if (TrainPlatformConnection && TrainPlatformConnection->IsValidLowLevel())
 				{
 					TrainPlatform = TrainPlatformConnection->GetPlatformOwner();
 				} else


### PR DESCRIPTION
The compiler UE uses for Windows appears to generate code that allows this, whereas clang doesn't.