### PR TITLE
Normalize train power. Add drone port names.

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -247,25 +247,24 @@ TSharedPtr<FJsonValue> ConvertStringToFJsonValue(const FString& JsonString)
 }
 
 TSharedPtr<FJsonObject> UFRM_Library::getPowerConsumptionJSON(UFGPowerInfoComponent* PowerInfo) {
-	return UFRM_Library::getPowerConsumptionJSON(PowerInfo, 0);
-}
-
-TSharedPtr<FJsonObject> UFRM_Library::getPowerConsumptionJSON(UFGPowerInfoComponent* PowerInfo, float additionalPowerConsumed) {
 	TSharedPtr<FJsonObject> JCircuit = MakeShared<FJsonObject>();
 	int32 CircuitGroupID = -1;
 	int32 CircuitID = -1;
-	float PowerConsumed = additionalPowerConsumed;
+	float PowerConsumed = 0;
+	float MaxPowerConsumed = 0;
 
 	if (IsValid(PowerInfo)) {
 		UFGPowerCircuit* PowerCircuit = PowerInfo->GetPowerCircuit();
 		if (IsValid(PowerCircuit)) {
 			CircuitGroupID = PowerCircuit->GetCircuitGroupID();
 			CircuitID = PowerCircuit->GetCircuitID();
-			PowerConsumed = PowerInfo->GetActualConsumption() + additionalPowerConsumed;
+			PowerConsumed = PowerInfo->GetActualConsumption();
+			MaxPowerConsumed = PowerInfo->GetMaximumTargetConsumption();
 		}
 	}
 	JCircuit->Values.Add("CircuitGroupID", MakeShared<FJsonValueNumber>(CircuitGroupID));
 	JCircuit->Values.Add("CircuitID", MakeShared<FJsonValueNumber>(CircuitID));
 	JCircuit->Values.Add("PowerConsumed", MakeShared<FJsonValueNumber>(PowerConsumed));
+	JCircuit->Values.Add("MaxPowerConsumed", MakeShared<FJsonValueNumber>(MaxPowerConsumed));
 	return JCircuit;
 };

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
@@ -178,8 +178,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 		float Potential = Generator->GetCurrentPotential();
 		float PotentialCapacity = Generator->CalcPowerProductionCapacityForPotential(Potential);
 
-		int32 CircuitID = 0; // PowerInfo->GetPowerCircuit()->GetCircuitID();
-
 		float BaseProduction = PowerInfo->GetBaseProduction();
 		float DynProductionCapacity = PowerInfo->GetDynamicProductionCapacity();
 		float DynProductionDemand = PowerInfo->GetDynamicProductionDemandFactor() * 100;
@@ -189,7 +187,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 		JGenerator->Values.Add("Name", MakeShared<FJsonValueString>(Generator->mDisplayName.ToString()));
 		JGenerator->Values.Add("ClassName", MakeShared<FJsonValueString>(Generator->GetClass()->GetName()));
 		JGenerator->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Cast<AActor>(Generator))));
-		JGenerator->Values.Add("CircuitID", MakeShared<FJsonValueNumber>(CircuitID));
 		JGenerator->Values.Add("BaseProd", MakeShared<FJsonValueNumber>(Generator->GetPowerProductionCapacity()));
 		JGenerator->Values.Add("DynamicProdCapacity", MakeShared<FJsonValueNumber>(DynProductionCapacity));
 		JGenerator->Values.Add("DynamicProdDemandFactor", MakeShared<FJsonValueNumber>(DynProductionDemand));
@@ -211,6 +208,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 		JGenerator->Values.Add("AvailableFuel", MakeShared<FJsonValueArray>(JFuelArray));
 		JGenerator->Values.Add("WasteInventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(WasteInventory)));
 		JGenerator->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(Cast<AActor>(Generator), Generator->mDisplayName.ToString(), Generator->mDisplayName.ToString())));
+		JGenerator->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Generator->GetPowerInfo())));
 
 		JGeneratorArray.Add(MakeShared<FJsonValueObject>(JGenerator));
 	};

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -155,7 +155,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 		float TransferRate = 0;
 		float InFlowRate = 0;
 		float OutFlowRate = 0;
-		float PowerConsumption = 0;
 		
 		TSharedPtr<FJsonObject> JTrainStation = MakeShared<FJsonObject>();
 		TArray<TSharedPtr<FJsonValue>> JCargoInventory;
@@ -187,7 +186,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 				JTrainPlatform->Values.Add("Name", MakeShared<FJsonValueString>(TrainPlatform->mDisplayName.ToString()));
 				JTrainPlatform->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(TrainPlatform->GetClass())));
 				JTrainPlatform->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(TrainPlatform)));
-				JTrainPlatform->Values.Add("PowerConsumption", MakeShared<FJsonValueNumber>(0));
+				JTrainPlatform->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(TrainPlatform->GetPowerInfo())));
 				JTrainPlatform->Values.Add("TransferRate", MakeShared<FJsonValueNumber>(0));
 				JTrainPlatform->Values.Add("InflowRate", MakeShared<FJsonValueNumber>(0));
 				JTrainPlatform->Values.Add("OutflowRate", MakeShared<FJsonValueNumber>(0));
@@ -221,17 +220,14 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 			float CargoTransferRate = 0;
 			float CargoInFlowRate = 0;
 			float CargoOutFlowRate = 0;
-			float CargoPowerConsumption = 0;
 
 			CargoTransferRate = TrainPlatformCargo->GetCurrentItemTransferRate();
 			CargoInFlowRate = TrainPlatformCargo->GetInflowRate();
 			CargoOutFlowRate = TrainPlatformCargo->GetOutflowRate();
-			CargoPowerConsumption = TrainPlatformCargo->GetPowerInfo()->GetActualConsumption();
 
 			TransferRate = TransferRate + CargoTransferRate;
 			InFlowRate = InFlowRate + CargoInFlowRate;
 			OutFlowRate = OutFlowRate + CargoOutFlowRate;
-			PowerConsumption = PowerConsumption + CargoPowerConsumption;
 
 			FString LoadMode = TEXT("Unloading");
 			if (TrainPlatformCargo->GetIsInLoadMode()) { LoadMode = TEXT("Loading"); }
@@ -268,7 +264,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 			JTrainPlatform->Values.Add("Name", MakeShared<FJsonValueString>(TrainPlatformCargo->mDisplayName.ToString()));
 			JTrainPlatform->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(TrainPlatformCargo->GetClass())));
 			JTrainPlatform->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(TrainPlatformCargo)));
-			JTrainPlatform->Values.Add("PowerConsumption", MakeShared<FJsonValueNumber>(CargoPowerConsumption));
+			JTrainPlatform->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(TrainPlatformCargo->GetPowerInfo())));
 			JTrainPlatform->Values.Add("TransferRate", MakeShared<FJsonValueNumber>(CargoTransferRate));
 			JTrainPlatform->Values.Add("InflowRate", MakeShared<FJsonValueNumber>(CargoInFlowRate));
 			JTrainPlatform->Values.Add("OutflowRate", MakeShared<FJsonValueNumber>(CargoOutFlowRate));
@@ -302,7 +298,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 		JTrainStation->Values.Add("OutflowRate", MakeShared<FJsonValueNumber>(OutFlowRate));
 		JTrainStation->Values.Add("CargoInventory", MakeShared<FJsonValueArray>(JTrainPlatformArray));
 		JTrainStation->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(TrainStation, TrainStation->GetStationName().ToString(), TEXT("Train Station"))));
-		JTrainStation->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(TrainStation->GetStation()->GetPowerInfo(), PowerConsumption)));
+		JTrainStation->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(TrainStation->GetStation()->GetPowerInfo())));
 
 		JTrainStationArray.Add(MakeShared<FJsonValueObject>(JTrainStation));
 	};

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Drones.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Drones.h
@@ -22,4 +22,7 @@ class FICSITREMOTEMONITORING_API UFRM_Drones : public UBlueprintFunctionLibrary
 public:
 	static TArray<TSharedPtr<FJsonValue>> getDroneStation(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getDrone(UObject* WorldContext);
+
+private:
+	static FString getDronePortName(AFGBuildableDroneStation* DroneStation);
 };

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
@@ -44,5 +44,4 @@ public:
 
 	static TSharedPtr<FJsonValue> ConvertStringToFJsonValue(const FString& JsonString);
 	static TSharedPtr<FJsonObject> getPowerConsumptionJSON(UFGPowerInfoComponent* powerInfo);
-	static TSharedPtr<FJsonObject> getPowerConsumptionJSON(UFGPowerInfoComponent* powerInfo, float modifier);
 };


### PR DESCRIPTION
* Add max power consumed stat to power metrics
* Normalize train power. All train platforms report their power info stat.
  * Station no longer aggregates all power inside it, simplifying some math.
* Add drone names for drones (closes #123 )