### PR TITLE
feat: add ID fields to many endpoints

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Drones.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Drones.cpp
@@ -19,7 +19,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Drones::getDroneStation(UObject* WorldContex
 	// Factory Building Production Stats
 	for (AFGBuildableDroneStation* DroneStation : DroneStations) {
 		
-		TSharedPtr<FJsonObject> JDroneStation = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JDroneStation = UFRM_Library::CreateBaseJsonObject(DroneStation);
 
 		// get fuel inventory
 		TMap<TSubclassOf<UFGItemDescriptor>, int32> FuelInventory = UFRM_Library::GetGroupedInventoryItems(DroneStation->GetFuelInventory());
@@ -128,15 +128,10 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Drones::getDrone(UObject* WorldContext) {
 	TArray<TSharedPtr<FJsonValue>> JDroneArray;
 
 	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), AFGDroneVehicle::StaticClass(), FoundActors);
-	int32 Index = 0;
 
 	for (AActor* FoundActor : FoundActors) {
-		Index++;
-
-		TSharedPtr<FJsonObject> JDrone = MakeShared<FJsonObject>();
-
 		AFGDroneVehicle* Drone = Cast<AFGDroneVehicle>(FoundActor);
-
+		TSharedPtr<FJsonObject> JDrone = UFRM_Library::CreateBaseJsonObject(Drone);
 		EDroneFlyingMode Form = Drone->GetDroneMovementComponent()->GetFlyingMode();
 
 		FString FormString = "Unknown";
@@ -162,7 +157,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Drones::getDrone(UObject* WorldContext) {
 			PairedStation = UFRM_Drones::getDronePortName(Drone->GetHomeStation()->GetInfo()->GetPairedStation()->GetStation());
 		};
 
-		JDrone->Values.Add("ID", MakeShared<FJsonValueString>(Drone->GetName()));
 		JDrone->Values.Add("Name", MakeShared<FJsonValueString>(Drone->mDisplayName.ToString()));
 		JDrone->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Drone->GetClass())));
 		JDrone->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Drone)));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
@@ -14,7 +14,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getBelts(UObject* WorldContext, FRe
 
 		if (!IsValid(ConveyorBelt)) { continue; }
 
-		TSharedPtr<FJsonObject> JConveyorBelt = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JConveyorBelt = UFRM_Library::CreateBaseJsonObject(ConveyorBelt);
 		
 		UFGFactoryConnectionComponent* ConnectionZero = ConveyorBelt->GetConnection0();
 		UFGFactoryConnectionComponent* ConnectionOne = ConveyorBelt->GetConnection1();
@@ -80,7 +80,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getFactory(UObject* WorldContext, F
 
 		AFGBuildableManufacturer* Manufacturer = Cast<AFGBuildableManufacturer>(Buildable);
 
-		TSharedPtr<FJsonObject> JFactory = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JFactory = UFRM_Library::CreateBaseJsonObject(Buildable);
 		TArray<TSharedPtr<FJsonValue>> JProductArray;
 		TArray<TSharedPtr<FJsonValue>> JIngredientsArray;
 
@@ -156,7 +156,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getFactory(UObject* WorldContext, F
 			JIngredientsArray.Add(MakeShared<FJsonValueObject>(JIngredients));
 		};
 
-		JFactory->Values.Add("ID", MakeShared<FJsonValueString>(Manufacturer->GetName()));
 		JFactory->Values.Add("Name", MakeShared<FJsonValueString>(Manufacturer->mDisplayName.ToString()));
 		JFactory->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Manufacturer->GetClass())));
 		JFactory->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Cast<AActor>(Manufacturer))));
@@ -188,15 +187,16 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getHubTerminal(UObject* WorldContex
 
 	for (AFGBuildableHubTerminal* HubTerminal : Buildables) {
 
-		TSharedPtr<FJsonObject> JHubTerminal = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JHubTerminal = UFRM_Library::CreateBaseJsonObject(HubTerminal);
 		TSubclassOf<UFGSchematic> ActiveSchematic = SchematicManager->GetActiveSchematic();
 		FString SchematicName = UFGSchematic::GetSchematicDisplayName(ActiveSchematic).ToString();
 		AFGBuildableTradingPost* TradingPost = HubTerminal->GetTradingPost();
 		
-		TSharedPtr<FJsonObject> JSchematic = MakeShared<FJsonObject>();
 		TArray<TSharedPtr<FJsonValue>> JRecipeArray;
+		TSharedPtr<FJsonObject> JSchematic;
 
 		if (IsValid(ActiveSchematic)) {
+			JSchematic = UFRM_Library::CreateBaseJsonObject(ActiveSchematic);
 			TArray<TSharedPtr<FJsonValue>> JCosts;
 			TArray<TSubclassOf<UFGRecipe>> Recipes;
 
@@ -265,6 +265,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getHubTerminal(UObject* WorldContex
 			JSchematic->Values.Add("Cost", MakeShared<FJsonValueArray>(JCosts));
 		}
 		else {
+			JSchematic = MakeShared<FJsonObject>();
 			JSchematic->Values.Add("Name", MakeShared<FJsonValueString>(TEXT("No Milestone Selected")));
 			JSchematic->Values.Add("ClassName", MakeShared<FJsonValueString>(TEXT("Desc_Null_C")));
 			JSchematic->Values.Add("TechTier", MakeShared<FJsonValueNumber>(-1));
@@ -301,18 +302,15 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPowerSlug(UObject* WorldContext,
 	TArray<TSharedPtr<FJsonValue>> JSlugArray;
 
 	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), CrystalClass, FoundActors);
-	int Index = 0;
 	for (AActor* PowerActor : FoundActors) {
-		Index++;
-
 		const auto ItemPickup = Cast<AFGItemPickup>(PowerActor);
 		if (!ItemPickup) continue;
-
+		
 		auto PowerSlug = ItemPickup->GetPickupItems().Item;
 		const auto ItemClass = PowerSlug.GetItemClass();
 		if (!ItemClass) continue;
-
-		TSharedPtr<FJsonObject> JPowerSlug = MakeShared<FJsonObject>();
+		
+		TSharedPtr<FJsonObject> JPowerSlug = UFRM_Library::CreateBaseJsonObject(PowerActor);
 		FString SlugName;
 
 		if (ItemClass->GetName() == "Desc_Crystal") {
@@ -325,7 +323,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPowerSlug(UObject* WorldContext,
 			SlugName = "Purple Slug";
 		};
 
-		JPowerSlug->Values.Add("ID", MakeShared<FJsonValueNumber>(Index));
 		JPowerSlug->Values.Add("Name", MakeShared<FJsonValueString>(SlugName));
 		JPowerSlug->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(PowerActor->GetClass())));
 		JPowerSlug->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(PowerActor)));
@@ -348,7 +345,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getStorageInv(UObject* WorldContext
 
 	for (AFGBuildableStorage* StorageContainer : StorageContainers) {
 
-		TSharedPtr<FJsonObject> JStorage = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JStorage = UFRM_Library::CreateBaseJsonObject(StorageContainer);
 
 		// get inventory
 		TMap<TSubclassOf<UFGItemDescriptor>, int32> StorageInventory = UFRM_Library::GetGroupedInventoryItems(StorageContainer->GetStorageInventory());
@@ -398,7 +395,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getDropPod(UObject* WorldContext, F
 
 	for (AActor* FoundActor : FoundActors) {
 
-		TSharedPtr<FJsonObject> JDropPod = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JDropPod = UFRM_Library::CreateBaseJsonObject(FoundActor);
 
 		AFGDropPod* DropPod = Cast<AFGDropPod>(FoundActor);
 
@@ -423,7 +420,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getDropPod(UObject* WorldContext, F
 			JItemClass = UKismetSystemLibrary::GetClassDisplayName(DropPodCost.ItemCost.ItemClass);
 		};
 
-		JDropPod->Values.Add("ID", MakeShared<FJsonValueString>(DropPod->GetName()));
 		JDropPod->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(DropPod)));
 		JDropPod->Values.Add("Opened", MakeShared<FJsonValueBoolean>(DropPod->HasBeenOpened()));
 		JDropPod->Values.Add("Looted", MakeShared<FJsonValueBoolean>(DropPod->HasBeenLooted()));
@@ -450,14 +446,12 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getResourceExtractor(UObject* World
 
 	for (AFGBuildableResourceExtractor* Extractor : Extractors) {
 
-		TSharedPtr<FJsonObject> JExtractor = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JExtractor = UFRM_Library::CreateBaseJsonObject(Extractor);
 		TArray<TSharedPtr<FJsonValue>> JProductArray;
 		TArray<TSharedPtr<FJsonValue>> JIngredientsArray;
 
 		FString ItemName = TEXT("Desc_Null");
 		FString ItemClassName = TEXT("Desc_Null");
-		float ProdCycle = 0;
-		float Productivity = 0;
 		float CurrentProd = 0;
 		float MaxProd = 0;
 		int32 Amount = 0;
@@ -467,9 +461,9 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getResourceExtractor(UObject* World
 			TSubclassOf<UFGResourceDescriptor> ItemClass = ResourceClass->GetResourceClass();
 			ItemName = UFGItemDescriptor::GetItemName(ItemClass).ToString();
 			ItemClassName = UKismetSystemLibrary::GetClassDisplayName(ItemClass);
-			ProdCycle = Extractor->GetExtractionPerMinute();
-			Productivity = Extractor->GetProductivity();
-			UFGInventoryComponent* ExtractorInventory = Extractor->GetOutputInventory();
+			const float ProdCycle = Extractor->GetExtractionPerMinute();
+			const float Productivity = Extractor->GetProductivity();
+			const UFGInventoryComponent* ExtractorInventory = Extractor->GetOutputInventory();
 
 			Amount = ExtractorInventory->GetNumItems(ItemClass);
 			CurrentProd = Productivity * ProdCycle;
@@ -541,7 +535,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getRadarTower(UObject* WorldContext
 
 		UFGRadarTowerRepresentation* RadarData = RadarTower->FindRadarTowerRepresentation();
 
-		TSharedPtr<FJsonObject> JRadarTower = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JRadarTower = UFRM_Library::CreateBaseJsonObject(RadarTower);
 		TArray<TSharedPtr<FJsonValue>> JFaunaArray;
 		TArray<TSharedPtr<FJsonValue>> JSignalArray;
 		TArray<TSharedPtr<FJsonValue>> JFloraArray;
@@ -597,6 +591,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getRadarTower(UObject* WorldContext
 
 		TSet<TSubclassOf<UFGItemDescriptor>> FaunaKeys;
 		FaunaTMap.GetKeys(FaunaKeys);
+
 		for (TSubclassOf <UFGItemDescriptor> Fauna : FaunaKeys) {
 
 			TSharedPtr<FJsonObject> JFauna = MakeShared<FJsonObject>();
@@ -656,7 +651,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getResourceSinkBuilding(UObject* Wo
 	BuildableSubsystem->GetTypedBuildable<AFGBuildableResourceSink>(Buildables);
 
 	for (AFGBuildableResourceSink* Sink : Buildables) {
-		TSharedPtr<FJsonObject> JSinkBuilding = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JSinkBuilding = UFRM_Library::CreateBaseJsonObject(Sink);
 		JSinkBuilding->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Sink)));
 		JSinkBuilding->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Sink->GetPowerInfo())));
 		JResourceSinkBuildingArray.Add(MakeShared<FJsonValueObject>(JSinkBuilding));
@@ -673,7 +668,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPump(UObject* WorldContext, FReq
 	BuildableSubsystem->GetTypedBuildable<AFGBuildablePipelinePump>(BuildablePumps);
 
 	for (AFGBuildablePipelinePump* Pump : BuildablePumps) {
-		TSharedPtr<FJsonObject> JPump = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JPump = UFRM_Library::CreateBaseJsonObject(Pump);
 		JPump->Values.Add("Name", MakeShared<FJsonValueString>(Pump->mDisplayName.ToString()));
 		JPump->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Pump)));
 		JPump->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Pump->GetPowerInfo())));
@@ -691,7 +686,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPortal(UObject* WorldContext, FR
 	BuildableSubsystem->GetTypedBuildable<AFGBuildablePortal>(BuildablePortal);
 
 	for (AFGBuildablePortal* Portal : BuildablePortal) {
-		TSharedPtr<FJsonObject> JPortal = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JPortal = UFRM_Library::CreateBaseJsonObject(Portal);
 		JPortal->Values.Add("Name", MakeShared<FJsonValueString>(Portal->mDisplayName.ToString()));
 		JPortal->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Portal)));
 		JPortal->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Portal->GetPowerInfo())));
@@ -702,12 +697,13 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPortal(UObject* WorldContext, FR
 	BuildableSubsystem->GetTypedBuildable<AFGBuildablePortalSatellite>(BuildablePortalSatellite);
 
 	for (AFGBuildablePortalSatellite* Portal : BuildablePortalSatellite) {
-		TSharedPtr<FJsonObject> JPortal = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JPortal = UFRM_Library::CreateBaseJsonObject(Portal);
 		JPortal->Values.Add("Name", MakeShared<FJsonValueString>(Portal->mDisplayName.ToString()));
 		JPortal->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Portal)));
 		JPortal->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Portal->GetPowerInfo())));
 		JPortalArray.Add(MakeShared<FJsonValueObject>(JPortal));
 	}
+
 	return JPortalArray;
 }
 
@@ -720,7 +716,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getHypertube(UObject* WorldContext,
 	BuildableSubsystem->GetTypedBuildable<AFGPipeHyperStart>(HyperStart);
 
 	for (AFGPipeHyperStart* Hypertube : HyperStart) {
-		TSharedPtr<FJsonObject> JHypertube = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JHypertube = UFRM_Library::CreateBaseJsonObject(Hypertube);
 		JHypertube->Values.Add("Name", MakeShared<FJsonValueString>(Hypertube->mDisplayName.ToString()));
 		JHypertube->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Hypertube)));
 		JHypertube->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Hypertube->GetPowerInfo())));
@@ -738,7 +734,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getFrackingActivator(UObject* World
 	BuildableSubsystem->GetTypedBuildable<AFGBuildableFrackingActivator>(FrackingActivator);
 
 	for (AFGBuildableFrackingActivator* Fracking : FrackingActivator) {
-		TSharedPtr<FJsonObject> JFrackingActivator = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JFrackingActivator = UFRM_Library::CreateBaseJsonObject(Fracking);
 		JFrackingActivator->Values.Add("Name", MakeShared<FJsonValueString>(Fracking->mDisplayName.ToString()));
 		JFrackingActivator->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Fracking)));
 		JFrackingActivator->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Fracking->GetPowerInfo())));
@@ -758,7 +754,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getSpaceElevator(UObject* WorldCont
 
 	for (AFGBuildableSpaceElevator* SpaceElevator : SpaceElevators) {
 
-		TSharedPtr<FJsonObject> JSpaceElevator = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JSpaceElevator = UFRM_Library::CreateBaseJsonObject(SpaceElevator);
 		
 		TArray<TSharedPtr<FJsonValue>> JCurrentPhaseArray;
 		TArray<FRemainingPhaseCost> RemainingPhaseCost;
@@ -828,7 +824,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPipes(UObject* WorldContext, FRe
 
 	for (AFGBuildablePipeline* Pipe : Pipes) {
 
-		TSharedPtr<FJsonObject> JPipe = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JPipe = UFRM_Library::CreateBaseJsonObject(Pipe);
 
 		UFGPipeConnectionComponent* ConnectionZero = Pipe->GetPipeConnection0();
 		UFGPipeConnectionComponent* ConnectionOne = Pipe->GetPipeConnection1();
@@ -849,7 +845,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPipes(UObject* WorldContext, FRe
 
 	return JPipeArray;
 };
-
 
 TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getSessionInfo(UObject* WorldContext, FRequestData RequestData) {
 

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -188,6 +188,14 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Library::GetInventoryJSON(const TMap<TSubcla
 	return JInventoryArray;
 }
 
+TSharedPtr<FJsonObject> UFRM_Library::CreateBaseJsonObject(const UObject* Actor)
+{
+	TSharedPtr<FJsonObject> JObject = MakeShared<FJsonObject>();
+	JObject->Values.Add("ID", MakeShared<FJsonValueString>(Actor->GetName()));
+
+	return JObject;
+}
+
 TSharedPtr<FJsonObject> UFRM_Library::GetResourceNodeJSON(AActor* Actor, const bool bIncludeFeatures)
 {
 	AFGResourceNode* ResourceNode = Cast<AFGResourceNode>(Actor);
@@ -195,7 +203,7 @@ TSharedPtr<FJsonObject> UFRM_Library::GetResourceNodeJSON(AActor* Actor, const b
 		return nullptr;
 	}
 
-	TSharedPtr<FJsonObject> JResourceNode = MakeShared<FJsonObject>();
+	TSharedPtr<FJsonObject> JResourceNode = CreateBaseJsonObject(Actor);
 
 	// get purity
 	const EResourcePurity ResourcePurity = ResourceNode->GetResoucePurity();

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Player.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Player.cpp
@@ -9,11 +9,8 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Player::getPlayer(UObject* WorldContext) {
 	TArray<TSharedPtr<FJsonValue>> JPlayerArray;
 
 	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), AFGCharacterPlayer::StaticClass(), FoundActors);
-	int Index = 0;
 	for (AActor* Player : FoundActors) {
-		Index++;
-
-		TSharedPtr<FJsonObject> JPlayer = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JPlayer = UFRM_Library::CreateBaseJsonObject(Player);
 
 		AFGCharacterPlayer* PlayerCharacter = Cast<AFGCharacterPlayer>(Player);
 		APlayerState* PlayerState = PlayerCharacter->GetPlayerState();
@@ -27,7 +24,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Player::getPlayer(UObject* WorldContext) {
 		//TODO: Find way to get player's name when they are offline
 		FString PlayerName = PlayerCharacter->mCachedPlayerName;
 
-		JPlayer->Values.Add("ID", MakeShared<FJsonValueNumber>(Index));
 		JPlayer->Values.Add("Name", MakeShared<FJsonValueString>(PlayerName));
 		JPlayer->Values.Add("ClassName", MakeShared<FJsonValueString>(Player->GetClass()->GetName()));
 		JPlayer->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Player))); 
@@ -52,11 +48,8 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Player::getDoggo(UObject* WorldContext) {
 	TArray<TSharedPtr<FJsonValue>> JDoggoArray;
 
 	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), DoggoClass, FoundActors);
-	int Index = 0;
 	for (AActor* Doggo : FoundActors) {
-		Index++;
-
-		TSharedPtr<FJsonObject> JDoggo = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JDoggo = UFRM_Library::CreateBaseJsonObject(Doggo);
 
 		AFicsitRemoteMonitoring* ModSubsystem = AFicsitRemoteMonitoring::Get(WorldContext->GetWorld());
 		fgcheck(ModSubsystem);
@@ -68,7 +61,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Player::getDoggo(UObject* WorldContext) {
 		ModSubsystem->GetDoggoInfo_BIE(Doggo, DisplayName, InventoryStacks);
 		TMap<TSubclassOf<UFGItemDescriptor>, int32> DoggoInventory = UFRM_Library::GetGroupedInventoryItems(InventoryStacks);
 
-		JDoggo->Values.Add("ID", MakeShared<FJsonValueNumber>(Index));
 		JDoggo->Values.Add("Name", MakeShared<FJsonValueString>(DisplayName));
 		JDoggo->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Doggo->GetClass())));
 		JDoggo->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Doggo)));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Production.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Production.cpp
@@ -258,7 +258,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Production::getResourceSink(UObject* WorldCo
 
 TSharedPtr<FJsonObject> UFRM_Production::getRecipe(UObject* WorldContext, TSubclassOf<UFGRecipe> Recipe) {
 	
-	TSharedPtr<FJsonObject> JRecipe = MakeShared<FJsonObject>();
+	TSharedPtr<FJsonObject> JRecipe = UFRM_Library::CreateBaseJsonObject(Recipe);
 	
 	AFicsitRemoteMonitoring* ModSubsystem = AFicsitRemoteMonitoring::Get(WorldContext->GetWorld());
 	fgcheck(ModSubsystem);
@@ -365,9 +365,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Production::getRecipes(UObject* WorldContext
 	fgcheck(ModSubsystem);
 
 	for (TSubclassOf<UFGSchematic> Schematic : Schematics) {
-
-		TSharedPtr<FJsonObject> JSchematic = MakeShared<FJsonObject>();
-
 		TArray<TSubclassOf<UFGRecipe>> Recipes;
 
 		bool Purchased = false;
@@ -407,7 +404,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Production::getSchematics(UObject* WorldCont
 
 	for (TSubclassOf<UFGSchematic> Schematic : Schematics) {
 
-		TSharedPtr<FJsonObject> JSchematic = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JSchematic = UFRM_Library::CreateBaseJsonObject(Schematic);
 
 		TArray<TSharedPtr<FJsonValue>> JRecipeArray;
 		TArray<TSubclassOf<UFGRecipe>> Recipes;
@@ -454,7 +451,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Production::getSchematics(UObject* WorldCont
 		}
 
 		JSchematic->Values.Add("Name", MakeShared<FJsonValueString>(UFGSchematic::GetSchematicDisplayName(Schematic).ToString()));
-		JSchematic->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Schematic->GetClass())));
+		JSchematic->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Schematic)));
 		JSchematic->Values.Add("TechTier", MakeShared<FJsonValueNumber>(UFGSchematic::GetTechTier(Schematic)));
 		JSchematic->Values.Add("Type", MakeShared<FJsonValueString>(SchematicType));
 		JSchematic->Values.Add("Recipes", MakeShared<FJsonValueArray>(JRecipeArray));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Trains.cpp
@@ -13,7 +13,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrains(UObject* WorldContext) {
 
 	for (AFGTrain* Train : Trains) {
 
-		TSharedPtr<FJsonObject> JTrain = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JTrain = UFRM_Library::CreateBaseJsonObject(Train);
 		TArray<TSharedPtr<FJsonValue>> JTimetableArray;
 
 		AFGLocomotive* MasterTrain = Train->GetMultipleUnitMaster();
@@ -156,7 +156,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 		float InFlowRate = 0;
 		float OutFlowRate = 0;
 		
-		TSharedPtr<FJsonObject> JTrainStation = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JTrainStation = UFRM_Library::CreateBaseJsonObject(TrainStation);
 		TArray<TSharedPtr<FJsonValue>> JCargoInventory;
 		TArray<TSharedPtr<FJsonValue>> JCargoStations;
 
@@ -177,7 +177,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Trains::getTrainStation(UObject* WorldContex
 		
 		while (!bCompleted) {	
 			AFGBuildableTrainPlatformCargo* TrainPlatformCargo = Cast<AFGBuildableTrainPlatformCargo>(TrainPlatform);
-			TSharedPtr<FJsonObject> JTrainPlatform = MakeShared<FJsonObject>();
+			TSharedPtr<FJsonObject> JTrainPlatform = UFRM_Library::CreateBaseJsonObject(TrainPlatform);
 			TMap<TSubclassOf<UFGItemDescriptor>, int32> TrainPlatformInventory;
 			
 			// Skips but does not stop checking for AFGBuildableTrainPlatformCargo

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Vehicles.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Vehicles.cpp
@@ -11,7 +11,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getTruckStation(UObject* WorldCont
 	// Factory Building Production Stats
 	for (AFGBuildableDockingStation* TruckStation : Buildables) {
 
-		TSharedPtr<FJsonObject> JTruckStation = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JTruckStation = UFRM_Library::CreateBaseJsonObject(TruckStation);
 
 		FString LoadMode;
 		if (TruckStation->GetIsInLoadMode()) {
@@ -83,7 +83,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getVehicles(UObject* WorldContext,
 
 		if (Vehicle->GetClass()->IsChildOf(VehicleClass)) {
 			//UE_LOG(LogFRMAPI, Warning, TEXT("Processing vehicle '%s'"), *Vehicle->GetName());
-			TSharedPtr<FJsonObject> JVehicle = MakeShared<FJsonObject>();
+			TSharedPtr<FJsonObject> JVehicle = UFRM_Library::CreateBaseJsonObject(Vehicle);
 
 			AFGWheeledVehicle* WheeledVehicle = Cast<AFGWheeledVehicle>(Vehicle);
 			fgcheck(WheeledVehicle);
@@ -148,7 +148,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Vehicles::getVehicles(UObject* WorldContext,
 			//fgcheck(VehiclePath);
 			//FString PathName = VehiclePath->mPathName;
 
-			JVehicle->Values.Add("ID", MakeShared<FJsonValueString>(Vehicle->GetName()));
 			JVehicle->Values.Add("Name", MakeShared<FJsonValueString>(Vehicle->mDisplayName.ToString()));
 			JVehicle->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Vehicle->GetClass())));
 			JVehicle->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(Vehicle)));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_World.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_World.cpp
@@ -29,7 +29,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_World::GetResearchTrees(UObject* WorldContex
 			FIntPoint Coordinates;
 			TArray<FIntPoint> ParentCoordinates;
 			TArray<FIntPoint> UnhiddenByCoordinates;
-			TSharedPtr<FJsonObject> JResearchNode = MakeShared<FJsonObject>();
+			TSharedPtr<FJsonObject> JResearchNode = UFRM_Library::CreateBaseJsonObject(ResearchNode);
 
 			ModSubsystem->ResearchTreeNodeUnlockData_BIE(ResearchNode, ParentCoordinates, UnhiddenByCoordinates, Coordinates);
 

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Library.h
@@ -31,6 +31,7 @@ public:
 	static TArray<TSharedPtr<FJsonValue>> GetInventoryJSON(const TArray<FItemAmount>& Items);
 	static TSharedPtr<FJsonObject> GetItemValueObject(const TSubclassOf<UFGItemDescriptor>& Item, const int Amount);
 	static TSharedPtr<FJsonObject> GetResourceNodeJSON(AActor* Actor, const bool bIncludeFeatures = false);
+	static TSharedPtr<FJsonObject> CreateBaseJsonObject(const UObject* Actor);
 	static FString APItoJSON(TArray<TSharedPtr<FJsonValue>> JSONArray, UObject* WorldContext);
 	static bool IsIntInRange(int32 Number, int32 LowerBound, int32 UpperBound);
 


### PR DESCRIPTION
i added FRM_Library::CreateBaseJsonObject to create a base `MakeShared<FJsonObject>();` object with the ID field and added it to many endpoints
i use GetName as unique id (e.g. Build_SpaceElevator_C_2147393189) it seems that this is an unique id for the savegame.
GetUniqueID has each time the savegame will be reloaded (it's the UObject id of the current game)
if we want to change this, we can do that in CreateBaseJsonObject without changing it everywhere

i replaced the Index ID (0, 1, 2, ...) in drone, doggo and power slug endpoint
it's easier to work with the response of the api with an unique ID