### PR TITLE
fix: prevent crashing http server on invalid icon file

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -209,8 +209,12 @@ void AFicsitRemoteMonitoring::StartWebSocketServer()
 
                     if (FPaths::FileExists(FilePath)) {
                         HandleGetRequest(res, req, FilePath);
+                    	return;
                     }
 
+					res->writeStatus("404 Not Found");
+					AddResponseHeaders(res, false);
+					res->end();
                 });
 
                 app.get("/api/:APIEndpoint", [this, World](auto* res, auto* req) {


### PR DESCRIPTION
another fix 😄
it prevents crashing the http server/game if an invalid icon is opened

before: http://localhost:8080/Icons/Desc_Screw_C.png crashes the game
after: 404 will be returned, no crash