### PR TITLE
reduce reliance on LoadObject

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Drones.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Drones.cpp
@@ -124,11 +124,10 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Drones::getDroneStation(UObject* WorldContex
 
 TArray<TSharedPtr<FJsonValue>> UFRM_Drones::getDrone(UObject* WorldContext) {
 
-	UClass* DroneClass = LoadObject<UClass>(nullptr, TEXT("/Script/FactoryGame.FGDroneVehicle"));
 	TArray<AActor*> FoundActors;
 	TArray<TSharedPtr<FJsonValue>> JDroneArray;
 
-	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), DroneClass, FoundActors);
+	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), AFGDroneVehicle::StaticClass(), FoundActors);
 	int32 Index = 0;
 
 	for (AActor* FoundActor : FoundActors) {

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
@@ -391,11 +391,10 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getWorldInv(UObject* WorldContext, 
 
 TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getDropPod(UObject* WorldContext, FRequestData RequestData) {
 
-	UClass* DropPodClass = LoadObject<UClass>(nullptr, TEXT("/Script/FactoryGame.FGDropPod"));
 	TArray<AActor*> FoundActors;
 	TArray<TSharedPtr<FJsonValue>> JDropPodArray;
 
-	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), DropPodClass, FoundActors);
+	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), AFGDropPod::StaticClass(), FoundActors);
 
 	for (AActor* FoundActor : FoundActors) {
 

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Player.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Player.cpp
@@ -5,11 +5,10 @@
 
 TArray<TSharedPtr<FJsonValue>> UFRM_Player::getPlayer(UObject* WorldContext) {
 
-	UClass* PlayerClass = LoadObject<UClass>(nullptr, TEXT("/Script/FactoryGame.FGCharacterPlayer"));
 	TArray<AActor*> FoundActors;
 	TArray<TSharedPtr<FJsonValue>> JPlayerArray;
 
-	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), PlayerClass, FoundActors);
+	UGameplayStatics::GetAllActorsOfClass(WorldContext->GetWorld(), AFGCharacterPlayer::StaticClass(), FoundActors);
 	int Index = 0;
 	for (AActor* Player : FoundActors) {
 		Index++;


### PR DESCRIPTION
Feel like this is less brittle to use the actual classes in GetAllActorsOfClass where possible. These are the ones I can find that can be replaced.