### PR TITLE
feat: add support for post requests and add setSwitches to update name, priority or status

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
@@ -75,6 +75,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getSwitches(UObject* WorldContext)
 		}
 
 		FString Name = PowerSwitch->GetBuildingTag_Implementation();
+		JSwitches->Values.Add("ID", MakeShared<FJsonValueString>(PowerSwitch->GetName()));
 		JSwitches->Values.Add("Name", MakeShared<FJsonValueString>(Name));
 		JSwitches->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(PowerSwitch->GetClass())));
 		JSwitches->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(PowerSwitch)));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
@@ -103,7 +103,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::setSwitches(UObject* WorldContext, FR
 	TArray<AFGBuildableCircuitSwitch*> PowerSwitches;
 	BuildableSubsystem->GetTypedBuildable<AFGBuildableCircuitSwitch>(PowerSwitches);
 
-	for (const auto BodyObject : RequestData.Body)
+	for (const auto& BodyObject : RequestData.Body)
 	{
 		auto JsonObject = BodyObject->AsObject();
 

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
@@ -61,7 +61,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getSwitches(UObject* WorldContext)
 
 	for (AFGBuildableCircuitSwitch* PowerSwitch : PowerSwitches) {
 
-		TSharedPtr<FJsonObject> JSwitches = MakeShared<FJsonObject>();
+		TSharedPtr<FJsonObject> JSwitches = UFRM_Library::CreateBaseJsonObject(PowerSwitch);
 
 		UFGCircuitConnectionComponent* ConnectionZero = PowerSwitch->GetConnection0();
 		UFGCircuitConnectionComponent* ConnectionOne = PowerSwitch->GetConnection1();
@@ -75,7 +75,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getSwitches(UObject* WorldContext)
 		}
 
 		FString Name = PowerSwitch->GetBuildingTag_Implementation();
-		JSwitches->Values.Add("ID", MakeShared<FJsonValueString>(PowerSwitch->GetName()));
 		JSwitches->Values.Add("Name", MakeShared<FJsonValueString>(Name));
 		JSwitches->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(PowerSwitch->GetClass())));
 		JSwitches->Values.Add("location", MakeShared<FJsonValueObject>(UFRM_Library::getActorJSON(PowerSwitch)));

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
@@ -141,6 +141,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::setSwitches(UObject* WorldContext, FR
 				if (JsonObject->HasField("name"))
 				{
 					PowerSwitch->SetBuildingTag_Implementation(Name);
+					PowerSwitch->SetHasBuildingTag_Implementation(Name.Len() > 0);
 					JResponse->Values.Add("Status", MakeShared<FJsonValueString>(PowerSwitch->GetBuildingTag_Implementation()));
 					bSuccess = true;
 				}

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Request.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Request.cpp
@@ -1,0 +1,107 @@
+﻿#pragma once
+
+#include "FRM_Request.h"
+
+void UFRM_RequestLibrary::SendErrorJson(uWS::HttpResponse<false>* res, const FString& Status, const FString& Json)
+{
+	res->writeStatus(std::string_view(TCHAR_TO_UTF8(*Status)).data());
+	AddResponseHeaders(res, true);
+
+	if (Json.Len() == 0)
+	{
+		res->end();
+		return;
+	}
+
+	res->end(TCHAR_TO_UTF8(*Json));
+}
+
+void UFRM_RequestLibrary::SendErrorMessage(uWS::HttpResponse<false>* res, const FString& Status, const FString& Message)
+{
+	const TSharedPtr<FJsonObject> JsonObject = MakeShared<FJsonObject>();
+	JsonObject->Values.Add("error", MakeShared<FJsonValueString>(Message));
+	SendErrorJson(res, Status, JsonObjectToString(JsonObject, false));
+}
+
+void UFRM_RequestLibrary::AddResponseHeaders(uWS::HttpResponse<false>* res, const bool bIncludeContentType)
+{
+	res
+		->writeHeader("Access-Control-Allow-Origin", "*")
+		// uWebSockets does not automatically handle the closing of HTTP connections.
+		// Therefore, we instruct the client to close the connection by setting the "Connection" header to "close"
+		// instead of using "keep-alive" (default).
+		->writeHeader("Connection", "close");
+
+	if (bIncludeContentType) res->writeHeader("Content-Type", "application/json");
+}
+
+TSharedPtr<FJsonObject> UFRM_RequestLibrary::GenerateError(const FString& Message)
+{
+	const TSharedPtr<FJsonObject> JError = MakeShared<FJsonObject>();
+	JError->Values.Add("error", MakeShared<FJsonValueString>(*Message));
+
+	return JError;
+}
+
+TSharedPtr<FJsonObject> GetFieldError(const FString& FieldName)
+{
+	return UFRM_RequestLibrary::GenerateError(FString::Printf(TEXT("Missing %ls field."), *FieldName));
+}
+
+TSharedPtr<FJsonObject> UFRM_RequestLibrary::TryGetStringField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, FString& OutString, TArray<TSharedPtr<FJsonValue>>& OutResponses)
+{
+	if (JsonObject->TryGetStringField(FieldName, OutString)) return nullptr;
+
+	const TSharedPtr<FJsonObject> JError = GetFieldError(FieldName);
+	OutResponses.Add(MakeShared<FJsonValueObject>(JError));
+
+	return JError;
+}
+
+TSharedPtr<FJsonObject> UFRM_RequestLibrary::TryGetBoolField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, bool& OutBool, TArray<TSharedPtr<FJsonValue>>& OutResponses)
+{
+	if (JsonObject->TryGetBoolField(FieldName, OutBool)) return nullptr;
+
+	const TSharedPtr<FJsonObject> JError = GetFieldError(FieldName);
+	OutResponses.Add(MakeShared<FJsonValueObject>(JError));
+
+	return JError;
+}
+
+FString UFRM_RequestLibrary::JsonArrayToString(const TArray<TSharedPtr<FJsonValue>>& JsonArray, const bool JSONDebugMode) {
+	FString OutputString;
+
+	// Choose Pretty or Condensed print policy based on JSONDebugMode
+	if (JSONDebugMode) {
+		TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&OutputString);
+		if (FJsonSerializer::Serialize(JsonArray, Writer)) {
+			return OutputString;
+		}
+	} else {
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&OutputString);
+		if (FJsonSerializer::Serialize(JsonArray, Writer)) {
+			return OutputString;
+		}
+	}
+	
+	return TEXT("Error: Unable to serialize JSON array");
+}
+
+FString UFRM_RequestLibrary::JsonObjectToString(const TSharedPtr<FJsonObject>& JsonObject, const bool JSONDebugMode) {
+	FString OutputString;
+
+	// Choose Pretty or Condensed print policy based on JSONDebugMode
+	if (JSONDebugMode) {
+		TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer = TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&OutputString);
+		if (FJsonSerializer::Serialize(JsonObject.ToSharedRef(), Writer)) {
+			return OutputString;
+		}
+	} else {
+		TSharedRef<TJsonWriter<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>> Writer = TJsonWriterFactory<TCHAR, TCondensedJsonPrintPolicy<TCHAR>>::Create(&OutputString);
+		if (FJsonSerializer::Serialize(JsonObject.ToSharedRef(), Writer)) {
+			return OutputString;
+		}
+	}
+
+	return TEXT("Error: Unable to serialize JSON object");
+}

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -227,6 +227,14 @@ void AFicsitRemoteMonitoring::StartWebSocketServer()
                     HandleApiRequest(World, res, req, Endpoint, RequestData);
                 });
 
+            	app.options("/*", [this, World](auto* res, uWS::HttpRequest* req)
+            	{
+            		UFRM_RequestLibrary::AddResponseHeaders(res, false);
+            		res->writeHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            			->writeHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+            		res->end();
+            	});
+            	
             	app.post("/*", [this, World](auto* res, uWS::HttpRequest* req)
             	{
 		            const std::string URL(req->getUrl().begin(), req->getUrl().end());

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Power.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Power.h
@@ -13,6 +13,7 @@
 #include "Buildables\FGBuildableGeneratorNuclear.h"
 #include "FGPowerCircuit.h"
 #include "FGCircuitSubsystem.h"
+#include "FRM_RequestData.h"
 #include "FRM_Power.generated.h"
 
 UCLASS()
@@ -23,6 +24,7 @@ class FICSITREMOTEMONITORING_API UFRM_Power : public UFGBlueprintFunctionLibrary
 public:
 	static TArray<TSharedPtr<FJsonValue>> getPower(UObject* WorldContext);
 	static TArray<TSharedPtr<FJsonValue>> getSwitches(UObject* WorldContext);
+	static TArray<TSharedPtr<FJsonValue>> setSwitches(UObject* WorldContext, FRequestData RequestData);
 	static TArray<TSharedPtr<FJsonValue>> getGenerators(UObject* WorldContext, UClass* TypedBuildable);
 	static TArray<TSharedPtr<FJsonValue>> getPowerUsage(UObject* WorldContext);
 	

--- a/Source/FicsitRemoteMonitoring/Public/FRM_Request.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_Request.h
@@ -1,0 +1,24 @@
+﻿#pragma once
+
+#include "FGBlueprintFunctionLibrary.h"
+#include "ThirdParty/uWebSockets/App.h"
+#include "FRM_Request.generated.h"
+
+UCLASS()
+class FICSITREMOTEMONITORING_API UFRM_RequestLibrary : public UFGBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	static void SendErrorJson(uWS::HttpResponse<false>* res, const FString& Status, const FString& Json);
+	static void SendErrorMessage(uWS::HttpResponse<false>* res, const FString& Status, const FString& Message);
+
+	static void AddResponseHeaders(uWS::HttpResponse<false>* res, const bool bIncludeContentType);
+
+	static TSharedPtr<FJsonObject> GenerateError(const FString& Message);
+	static TSharedPtr<FJsonObject> TryGetStringField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, FString& OutString, TArray<TSharedPtr<FJsonValue>>& OutResponses);
+	static TSharedPtr<FJsonObject> TryGetBoolField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, bool& OutBool, TArray<TSharedPtr<FJsonValue>>& OutResponses);
+	
+	static FString JsonArrayToString(const TArray<TSharedPtr<FJsonValue>>& JsonArray, const bool JSONDebugMode);
+	static FString JsonObjectToString(const TSharedPtr<FJsonObject>& JsonObject, const bool JSONDebugMode);
+};

--- a/Source/FicsitRemoteMonitoring/Public/FRM_RequestData.h
+++ b/Source/FicsitRemoteMonitoring/Public/FRM_RequestData.h
@@ -9,4 +9,8 @@ struct FRequestData
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Request Data")
 	TMap<FString, FString> QueryParams;
+
+	FString Method = "GET";
+
+	TArray<TSharedPtr<FJsonValue>> Body;
 };

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -80,6 +80,9 @@ struct FAPIEndpoint {
 	FString APIName;
 
 	UPROPERTY()
+	FString Method = "GET";
+
+	UPROPERTY()
 	bool bGetAll;
 
 	UPROPERTY()
@@ -125,16 +128,16 @@ public:
 	/** Get the subsystem in the current world, can be nullptr, e.g. on game ending (destroy) or game startup. */
 	static AFicsitRemoteMonitoring* Get(UWorld* world);
 
+	void RegisterEndpoint(const FString& Method, const FString& APIName, bool bGetAll, bool bRequireGameThread, bool bUseFirstObject, FEndpointFunction FunctionPtr);
 	void RegisterEndpoint(const FString& APIName, bool bGetAll, bool bRequireGameThread, FEndpointFunction FunctionPtr);
 	void RegisterEndpoint(const FString& APIName, bool bGetAll, bool bRequireGameThread, bool bUseFirstObject, FEndpointFunction FunctionPtr);
+	void RegisterPostEndpoint(const FString& APIName, bool bGetAll, bool bRequireGameThread, FEndpointFunction FunctionPtr);
 
 	UFUNCTION(BlueprintCallable, Category = "Ficsit Remote Monitoring")
 	FString HandleEndpoint (UObject* WorldContext, FString InEndpoint, FRequestData RequestData, bool& bSuccess);
 
 	//FFGServerErrorResponse HandleCSSEndpoint(FString& out_json, FString InEndpoin);
 
-	FString JsonArrayToString(TArray<TSharedPtr<FJsonValue>> JsonArray);
-	FString JsonObjectToString(TSharedPtr<FJsonObject> JsonObject);
 	FCallEndpointResponse CallEndpoint(UObject* WorldContext, FString InEndpoint, FRequestData RequestData, bool& bSuccess);
 
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ficsit Remote Monitoring")
@@ -175,7 +178,7 @@ public:
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ficsit Remote Monitoring")
 	void InitSerialDevice();
 
-	void HandleApiRequest(UObject* World, uWS::HttpResponse<false>* res, uWS::HttpRequest* req, FString Endpoint);
+	void HandleApiRequest(UObject* World, uWS::HttpResponse<false>* res, uWS::HttpRequest* req, FString Endpoint, FRequestData RequestData);
 
 	void InitAPIRegistry();
 	void InitOutageNotification();
@@ -437,6 +440,10 @@ public:
 	
 	void getSwitches(UObject* WorldContext, FRequestData RequestData, TArray<TSharedPtr<FJsonValue>>& OutJsonArray) {		
 		OutJsonArray = UFRM_Power::getSwitches(WorldContext);
+	}
+	
+	void setSwitches(UObject* WorldContext, FRequestData RequestData, TArray<TSharedPtr<FJsonValue>>& OutJsonArray) {		
+		OutJsonArray = UFRM_Power::setSwitches(WorldContext, RequestData);
 	}
 	
 	void getTractor(UObject* WorldContext, FRequestData RequestData, TArray<TSharedPtr<FJsonValue>>& OutJsonArray) {		


### PR DESCRIPTION
- support for POST requests, it accepts an array of objects or an object, the FRequestData.Body is always an array, so we don't need to check this manually in any endpoint and can execute multiple actions with one request
- Name in getSwitches is now the name of the power switch itself
- added Priority to getSwitches (-1 for power switch 0 - 8 for priority power switches)

example for a setSwitches request (curl):
```
curl --location 'http://localhost:8081/setSwitches' \
--header 'Content-Type: application/json' \
--data '{
    "ID": "Build_PriorityPowerSwitch_C_2147413991",
    "name": "hello",
    "status": false,
    "priority": 0
}'
```

every field is optional, only name, status OR priority is required to do an update in setSwitches
if you try to update multiple switches you could get an array with success & error objects like this:

request body:
```json
[ 
       {
        "ID": "Build_PowerSwitch_C_2147414481",
        "status": true
    },
    {
        "ID": "Build_PriorityPowerSwitch_C_2147413991",
        "name": "",
        "status": true,
        "priority": 3
    },
    {
        "ID": "Build_PriorityPowerSwitch_C_2147413991"
    },
    {
        "ID": "Build_PriorityPowerSwitch_C_21474139911",
        "name": "",
        "status": true,
        "priority": 3
    }
]
```

response:
```json
[
    {
        "ID": "Build_PowerSwitch_C_2147414481",
        "Status": true
    },
    {
        "ID": "Build_PriorityPowerSwitch_C_2147413991",
        "Status": true,
        "Priority": 3
    },
    {
        "error": "Missing field priority, name or status.",
        "ID": "Build_PriorityPowerSwitch_C_2147413991"
    },
    {
        "error": "Power Switch not found.",
        "ID": "Build_PriorityPowerSwitch_C_21474139911"
    }
]
```