### PR TITLE
feat: add stack size for items and fuel inventory to generators

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Library.cpp
@@ -163,6 +163,7 @@ TSharedPtr<FJsonObject> UFRM_Library::GetItemValueObject(const TSubclassOf<UFGIt
 	JItem->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(Item).ToString()));
 	JItem->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Item)));
 	JItem->Values.Add("Amount", MakeShared<FJsonValueNumber>(Amount));
+	JItem->Values.Add("MaxAmount", MakeShared<FJsonValueNumber>(UFGItemDescriptor::GetStackSize(Item)));
 
 	return JItem;
 }

--- a/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Power.cpp
@@ -209,11 +209,16 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 		EResourceForm FuelForm;
 		FString FormString = "Geothermal";
 
+		TArray<TSharedPtr<FJsonValue>> JFuelInventory;
 		TArray<TSharedPtr<FJsonValue>> JFuelArray;
 		TSharedPtr<FJsonObject> JSupplemental = MakeShared<FJsonObject>();
 
-		if (IsValid(GeneratorFuel)) {
+		if (IsValid(GeneratorFuel) || IsValid(GeneratorNuclear))
+		{
+			JFuelInventory = UFRM_Library::GetInventoryJSON(UFRM_Library::GetGroupedInventoryItems(GeneratorFuel->GetFuelInventory()));
+		}
 
+		if (IsValid(GeneratorFuel)) {
 			TSubclassOf<UFGItemDescriptor> Supplemental = GeneratorFuel->GetSupplementalResourceClass();
 
 			JSupplemental->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(Supplemental).ToString()));
@@ -227,8 +232,8 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 			UFGInventoryComponent* FuelInventory = GeneratorFuel->GetFuelInventory();
 			
 			TArray<TSubclassOf<UFGItemDescriptor>> FuelClasses = GeneratorFuel->GetAvailableFuelClasses(FuelInventory);
-			for (TSubclassOf<UFGItemDescriptor> FuelClass : FuelClasses) {
-
+			for (TSubclassOf<UFGItemDescriptor> FuelClass : FuelClasses)
+			{
 				TSharedPtr<FJsonObject> JFuel = MakeShared<FJsonObject>();
 
 				auto EnergyValue = UFGInventoryLibrary::GetAmountConvertedByForm(UFGItemDescriptor::GetEnergyValue(FuelClass), UFGItemDescriptor::GetForm(FuelClass));
@@ -277,7 +282,6 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 		float GeoMaxPower = 0;
 
 		if (IsValid(GeneratorGeo)) {
-
 			GeoMinPower = GeneratorGeo->GetMinPowerProduction();
 			GeoMaxPower = GeneratorGeo->GetMaxPowerProduction();
 		}
@@ -314,8 +318,9 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Power::getGenerators(UObject* WorldContext, 
 		JGenerator->Values.Add("GeoMaxPower", MakeShared<FJsonValueNumber>(GeoMaxPower));
 		JGenerator->Values.Add("AvailableFuel", MakeShared<FJsonValueArray>(JFuelArray));
 		JGenerator->Values.Add("WasteInventory", MakeShared<FJsonValueArray>(UFRM_Library::GetInventoryJSON(WasteInventory)));
-		JGenerator->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(Cast<AActor>(Generator), Generator->mDisplayName.ToString(), Generator->mDisplayName.ToString())));
+		JGenerator->Values.Add("FuelInventory", MakeShared<FJsonValueArray>(JFuelInventory));
 		JGenerator->Values.Add("PowerInfo", MakeShared<FJsonValueObject>(UFRM_Library::getPowerConsumptionJSON(Generator->GetPowerInfo())));
+		JGenerator->Values.Add("features", MakeShared<FJsonValueObject>(UFRM_Library::getActorFeaturesJSON(Cast<AActor>(Generator), Generator->mDisplayName.ToString(), Generator->mDisplayName.ToString())));
 
 		JGeneratorArray.Add(MakeShared<FJsonValueObject>(JGenerator));
 	};


### PR DESCRIPTION
- MaxAmount (stacksize) for items
- FuelInventory to getGenerators (e.g. biomass for a biomass burner or water & coal in a coal generator)