### PR TITLE
feat: add more fields to /getSessionInfo

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Factory.cpp
@@ -1,4 +1,5 @@
 #include "FRM_Factory.h"
+#include "FGTimeSubsystem.h"
 #include <FicsitRemoteMonitoring.h>
 
 #undef GetForm
@@ -848,10 +849,23 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getPipes(UObject* WorldContext, FRe
 
 TArray<TSharedPtr<FJsonValue>> UFRM_Factory::getSessionInfo(UObject* WorldContext, FRequestData RequestData) {
 
+	const auto GameState = WorldContext->GetWorld()->GetGameState<AFGGameState>();
+	const AFGTimeOfDaySubsystem* TimeOfDaySubSystem = AFGTimeOfDaySubsystem::Get(WorldContext);
+
+	const auto PlayDuration = GameState->GetTotalPlayDuration();
+
 	TSharedPtr<FJsonObject> JSessionInfo = MakeShared<FJsonObject>();
-	auto gameState = WorldContext->GetWorld()->GetGameState<AFGGameState>();
-	FString SessionName = gameState->GetSessionName();
-	JSessionInfo->Values.Add("SessionName", MakeShared<FJsonValueString>(SessionName));
+	JSessionInfo->Values.Add("SessionName", MakeShared<FJsonValueString>(GameState->GetSessionName()));
+	JSessionInfo->Values.Add("DayLength", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetDayLength()));
+	JSessionInfo->Values.Add("NightLength", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetNightLength()));
+	JSessionInfo->Values.Add("PassedDays", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetPassedDays()));
+	JSessionInfo->Values.Add("NumberOfDaysSinceLastDeath", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetNumberOfDaysSinceLastDeath()));
+	JSessionInfo->Values.Add("Hours", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetHours()));
+	JSessionInfo->Values.Add("Minutes", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetMinutes()));
+	JSessionInfo->Values.Add("Seconds", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetSeconds()));
+	JSessionInfo->Values.Add("IsDay", MakeShared<FJsonValueBoolean>(TimeOfDaySubSystem->IsDay()));
+	JSessionInfo->Values.Add("TotalPlayDuration", MakeShared<FJsonValueNumber>(PlayDuration));
+	JSessionInfo->Values.Add("TotalPlayDurationText", MakeShared<FJsonValueString>(SecondsToTimeString(PlayDuration)));
 
 	TArray<TSharedPtr<FJsonValue>> JSessionInfoArray;
 	JSessionInfoArray.Add(MakeShared<FJsonValueObject>(JSessionInfo));


### PR DESCRIPTION
more fields for /getSessionInfo

- Hours, Minutes, Seconds = current game time
- DayLength = length of the day in minutes
- NightLength = length of the night in minutes
- PassedDays = passed days in this save
- NumberOfDaysSinceLastDeath = days since last incident
- IsDay = obviously true for day, false for night
- TotalPlayDuration = play time in seconds
- TotalPlayDurationText = formatted play time (142:20:33)