### PR TITLE
Add CLI commands for common development tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 Binaries/*
 Intermediate/*
 Saved/*
+
+# User-defined environment variables
+taskfile.local.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,9 +116,58 @@ If you wish to contribute to the mod, you will need to setup the [modding enviro
 
 - Setup the modding environment as described above.
 - Download or Clone the Ficsit Remote Monitoring Dev branch to your FactoryGame.uproject's Mods folder
-- Download or Clone the ArduinoKit to your FactoryGame.uproject's Mods folder. 
+- Download or Clone [ArduinoKit](https://github.com/porisius/ArduinoKit) to your FactoryGame.uproject's Mods folder. 
   - This is required for packing/testing the mod, due to handling potential Serial/RS232 Device Communication.
 - Continue from [here](https://docs.ficsit.app/satisfactory-modding/latest/Development/BeginnersGuide/project_setup.html#_generate_visual_studio_files) to compile the project for opening in Unreal Engine Editor.
+
+### Automation of common tasks
+
+Optionally, you can use [Task](https://taskfile.dev/) to perform some steps via the CLI instead of the Visual Studio or Unreal Editor GUI. This is not required in order to develop FRM, and you should still become familiar with the GUI-based workflow described above.
+
+ 1. If you are on Windows and you did not do so while setting up your modding environment, install and use "Git Bash". While Task does support Windows, FRM's task definitions assume that Linux-style commands (cp, mv, unzip) are available.
+ 2. [Install Task](https://taskfile.dev/installation/) via your preferred method. On Windows, [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) is available by default and is likely the best choice.
+
+    ```bash
+    winget install Task.Task
+    ```
+
+ 3. Close and re-open your terminal.
+ 4. View the available tasks.
+
+    ```bash
+    task
+    ```
+
+    The tasks are defined in [taskfile.yaml](taskfile.yaml) if you want to read what a task will do before running it.
+
+As an example, these commands would build and install the development version of the mod in a similar manner to Alpakit with the "copy to game folder" function enabled.
+
+```bash
+task package:dev
+task install
+```
+
+While the taskfile will use sensible defaults for the location of your Satisfactory and Unreal Engine installations, you may need to tell it where they are. Do this by creating a `.taskfile.local.yaml` file in the root of your FicsitRemoteMonitoring checkout.
+
+```yaml
+# taskfile.local.yaml
+
+# Required
+version: '3'
+
+vars:
+  SATISFACTORY_MOD_DIR: "C:/Games/Steam/steamapps/common/Satisfactory/FactoryGame/Mods"
+  UE_INSTALL_ROOT: "C:/ue"
+```
+
+For one-off usage they can also be set via the command line. See [Task's documentation](https://taskfile.dev/usage/#variables) for more information.
+
+```bash
+task install SATISFACTORY_MOD_DIR="example/path"
+```
+
+The default values for these variables can be found near the start of the [taskfile.yaml](taskfile.yaml).
+You can use either Unix (/) or Windows (\\) style paths regardless of your operating system.
 
 ### Improving The Documentation
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -1,0 +1,101 @@
+# Config for Taskfile - https://taskfile.dev/
+# See CONTRIBUTING.md
+
+version: "3"
+
+# Use a taskfile rather than a dotenv file since the latter currently makes using global variables difficult.
+# See https://github.com/go-task/task/issues/521
+includes:
+  local:
+    taskfile: taskfile.local.yaml
+    optional: true
+
+env:
+  # Defaults which are designed to be overridden in a taskfile.local.yaml.
+  # The 'default' syntax makes the correct value available in ${VAR} format.
+  SATISFACTORY_MOD_DIR: '{{ default "C:/Program Files (x86)/Steam/steamapps/common/Satisfactory/FactoryGame/Mods" .SATISFACTORY_MOD_DIR }}'
+  UE_INSTALL_ROOT: '{{ default "C:/Program Files/Unreal Engine - CSS" .UE_INSTALL_ROOT }}'
+
+  # The name of the mod
+  PROJECT_NAME: "{{ osBase .ROOT_DIR }}"
+
+  # Zip files created after using UE to package the mod
+  PACKAGE_OUTPUT_DIR: '{{ joinPath .ROOT_DIR "../../Saved/ArchivedPlugins" .PROJECT_NAME }}'
+  PACKAGE_OUT_WIN: '{{ print .PROJECT_NAME "-Windows.zip" }}'
+
+  # Path where the DLLs can be found
+  DLL_DIR: Source/ThirdParty/uWebSockets/lib
+  DLL_UV: '{{ joinPath .DLL_DIR "uv.dll" }}'
+  DLL_ZLIB: '{{ joinPath .DLL_DIR "zlib1.dll" }}'
+
+  # The Unreal Project file for SML
+  UPROJECT_FILE: '{{ joinPath .ROOT_DIR "../../FactoryGame.uproject" }}'
+
+tasks:
+  build:dev:
+    desc: Build the project in the "development editor" configuration
+    run: once
+    cmds:
+      - >-
+        '{{ joinPath .UE_INSTALL_ROOT "/Engine/Build/BatchFiles/Build.bat" }}'
+        FactoryEditor Win64 Development -project='{{ .UPROJECT_FILE }}'
+
+  install:
+    desc: Install the locally-built windows client version of the mod (requires bash)
+    run: once
+    env:
+      MOD_INSTALL_DIR: "{{ joinPath .SATISFACTORY_MOD_DIR .PROJECT_NAME }}"
+    cmds:
+      - rm -rf "${MOD_INSTALL_DIR}"
+      - unzip -q -d "${MOD_INSTALL_DIR}" '{{ joinPath .PACKAGE_OUTPUT_DIR .PACKAGE_OUT_WIN }}'
+      - >-
+        cp --no-clobber '{{ .DLL_UV }}' '{{ .DLL_ZLIB }}'
+        '{{ joinPath .SATISFACTORY_MOD_DIR .PROJECT_NAME "Binaries/Win64" }}'
+
+  package:dev:
+    desc: Create an installable Windows-client-only development version of the mod
+    run: once
+    cmds:
+      - task: uat:run
+        vars:
+          ARGS:
+            - -build
+            - -platform=Win64
+            - -nocompileeditor
+            - -installed
+
+  package:release:
+    desc: Create an release-ready installable version of the mod for both client and server
+    run: once
+    cmds:
+      - task: uat:run
+        vars:
+          ARGS:
+            - -build
+            - -platform=Win64
+            - -server
+            - -serverplatform=Win64+Linux
+            - -nocompileeditor
+            - -installed
+            - -merge
+
+  uat:run:
+    desc: Run the Unreal Automation Tool - args should be pre-shell-quoted
+    internal: true
+    run: when_changed
+    requires:
+      ARGS: []
+    cmds:
+      - >-
+        "{{ joinPath .UE_INSTALL_ROOT "/Engine/Build/BatchFiles/RunUAT.bat" }}"
+        -ScriptsForProject="{{ .UPROJECT_FILE }}" PackagePlugin -project="{{ .UPROJECT_FILE }}"
+        -clientconfig=Shipping -serverconfig=Shipping -utf8output -DLCName="{{ .PROJECT_NAME }}"
+        {{ .ARGS | join " " }}
+
+  vs:project:
+    desc: Generate Visual Studio project files
+    run: once
+    cmds:
+      - >-
+        '{{ joinPath .UE_INSTALL_ROOT "Engine/Binaries/Win64/UnrealVersionSelector.exe" }}'
+        -projectfiles '{{ .UPROJECT_FILE }}'

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -10,11 +10,10 @@ includes:
     taskfile: taskfile.local.yaml
     optional: true
 
-env:
+vars:
   # Defaults which are designed to be overridden in a taskfile.local.yaml.
-  # The 'default' syntax makes the correct value available in ${VAR} format.
-  SATISFACTORY_MOD_DIR: '{{ default "C:/Program Files (x86)/Steam/steamapps/common/Satisfactory/FactoryGame/Mods" .SATISFACTORY_MOD_DIR }}'
-  UE_INSTALL_ROOT: '{{ default "C:/Program Files/Unreal Engine - CSS" .UE_INSTALL_ROOT }}'
+  SATISFACTORY_MOD_DIR: "C:/Program Files (x86)/Steam/steamapps/common/Satisfactory/FactoryGame/Mods"
+  UE_INSTALL_ROOT: "C:/Program Files/Unreal Engine - CSS"
 
   # The name of the mod
   PROJECT_NAME: "{{ osBase .ROOT_DIR }}"
@@ -43,11 +42,11 @@ tasks:
   install:
     desc: Install the locally-built windows client version of the mod (requires bash)
     run: once
-    env:
+    vars:
       MOD_INSTALL_DIR: "{{ joinPath .SATISFACTORY_MOD_DIR .PROJECT_NAME }}"
     cmds:
-      - rm -rf "${MOD_INSTALL_DIR}"
-      - unzip -q -d "${MOD_INSTALL_DIR}" '{{ joinPath .PACKAGE_OUTPUT_DIR .PACKAGE_OUT_WIN }}'
+      - rm -rf '{{ .MOD_INSTALL_DIR }}'
+      - unzip -q -d '{{ .MOD_INSTALL_DIR }}' '{{ joinPath .PACKAGE_OUTPUT_DIR .PACKAGE_OUT_WIN }}'
       - >-
         cp --no-clobber '{{ .DLL_UV }}' '{{ .DLL_ZLIB }}'
         '{{ joinPath .SATISFACTORY_MOD_DIR .PROJECT_NAME "Binaries/Win64" }}'

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -58,11 +58,7 @@ tasks:
     cmds:
       - task: uat:run
         vars:
-          ARGS:
-            - -build
-            - -platform=Win64
-            - -nocompileeditor
-            - -installed
+          ARGS: [-build, -platform=Win64, -nocompileeditor, -installed]
 
   package:release:
     desc: Create an release-ready installable version of the mod for both client and server
@@ -71,13 +67,15 @@ tasks:
       - task: uat:run
         vars:
           ARGS:
-            - -build
-            - -platform=Win64
-            - -server
-            - -serverplatform=Win64+Linux
-            - -nocompileeditor
-            - -installed
-            - -merge
+            [
+              -build,
+              -platform=Win64,
+              -server,
+              -serverplatform=Win64+Linux,
+              -nocompileeditor,
+              -installed,
+              -merge,
+            ]
 
   uat:run:
     desc: Run the Unreal Automation Tool - args should be pre-shell-quoted


### PR DESCRIPTION
Per the conversation in Discord [starting just below here](https://discord.com/channels/1142919853053841488/1142921725269524643/1312554990497173554), this adds some pre-defined command-line scripts using [Task](https://taskfile.dev/).

Opened as a draft since I'm not sure if there's an appetite for it. I figure if it's not worth adding to `main` then people who are interested can just grab the config and use it themselves. It works in my testing, though would obviously benefit from someone else trying it out.

 ```bash
 # Do the equivaliant of a dev Alpakit run and also copies the DLLs
 task package:dev && task install

 # Do the equivaliant of a release Alpakit run.
 task package:release

 # Do the equivelant of a "development editor" build in VS
 task build:dev

 # Regenerate VS project files
 task vs:project
 ```

I've updated the CONTRIBUTING.md with specific instructions.

These were adapted from another project I'm working on where I started using Task because I have to run a bunch of extra commands as part of the build process, however I thought that there might be some benefit to something similar for FRM even though it doesn't have those other requirements.

- Not needing to wait for the UE Editor to open just to run Alpakit is nice.
- Builds run without the editor open can be faster since the extra free memory can be enough for another parallel build worker.
- This could provide a nice place for any other tasks that there are in the future (tests, etc).
   
There are some caveats and notes.

- `task install` won't work under Powershell.
  - It *will* work under a default "Git Bash" install on Windows.
  - All the other tasks *will* work under PS.
  - I really tried. PS (at least 5.x, which comes standard on Win 10 and 11) is just not really designed for easy automation. A lot of work is required just for it to properly report errors, which you get for free with Bash.
  - As an example, Expand-Archive will happily extract a zip that doesn't exist to a directory that doesn't exist without throwing an error.
  - The extra level of indirection from Task's generic CLI runner was also making things annoying.
  - Worth noting that bash is available even on Windows Github Actions runners.
- I haven't added dependencies between tasks.
  - E.g. having package:* run build:dev.
  - Trivial to do but not strictly necessary for any of the tasks defined here.
- I thought about having it show an explicit error if ArduinoKit isn't present.
  - That is very annoying to do without using Bash.
- My choice of using Task was pretty arbitrary.
  - There's nothing similar available by default on Windows. Even Git Bash doesn't come with Make.
  - Make isn't great when most targets are 'phony' (don't create specific files) and also assumes paths won't have spaces.
  - The other option I know if is [just](https://github.com/casey/just). That's missing some (IMO) critical things, like the ability to skip up-to-date jobs.
  - Task has some of the same eccentricities with variables which seem to plague other YAML-templating-based tools like Ansible. I've documented them inline.