### PR TITLE
fix: ClassName in getSinkList, remove setSwitches from getAll

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FRM_Production.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FRM_Production.cpp
@@ -207,7 +207,7 @@ TArray<TSharedPtr<FJsonValue>> UFRM_Production::getSinkList(UObject* WorldContex
 		}
 
 		JSinkRow->Values.Add("Name", MakeShared<FJsonValueString>(UFGItemDescriptor::GetItemName(SinkRow->ItemClass).ToString()));
-		JSinkRow->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(SinkRow->ItemClass->GetClass())));
+		JSinkRow->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(SinkRow->ItemClass)));
 		JSinkRow->Values.Add("Points", MakeShared<FJsonValueNumber>(SinkPoints));
 		JSinkRow->Values.Add("PointsOverride", MakeShared<FJsonValueNumber>(SinkOverridden));
 

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -659,7 +659,7 @@ void AFicsitRemoteMonitoring::InitAPIRegistry()
 	RegisterEndpoint("getVehicles", true, false, &AFicsitRemoteMonitoring::getVehicles);
 
 	// post/write endpoints
-	RegisterPostEndpoint("setSwitches", true, true, &AFicsitRemoteMonitoring::setSwitches);
+	RegisterPostEndpoint("setSwitches", false, true, &AFicsitRemoteMonitoring::setSwitches);
 }
 
 void AFicsitRemoteMonitoring::InitOutageNotification() {


### PR DESCRIPTION
- setSwitches was called in /getAll endpoint
- ClassName in getSinkList was wrong (was always BlueprintGeneratedClass)