### PR TITLE
fix: prevent duplicate recipes in getRecipes

### DIFF
--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -140,6 +140,7 @@ public:
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ficsit Remote Monitoring")
 	void SchematicToRecipes_BIE(UObject* WorldContext, TSubclassOf<class UFGSchematic> schematicClass, TArray<TSubclassOf< class UFGRecipe >>& out_RecipeClasses, bool& Purchased, bool& HasUnlocks, bool& LockedAny, bool& LockedTutorial, bool& LockedDependent, bool& LockedPhase, bool& Tutorial);
 
+	// TODO unused can be removed
 	UFUNCTION(BlueprintImplementableEvent, Category = "Ficsit Remote Monitoring")
 	void RecipeNames_BIE(TSubclassOf<class UFGRecipe> recipeClass, FString& Name, FString& ClassName, FString& CategoryName);
 


### PR DESCRIPTION
i replaced the usage of RecipeNames_BIE (i would remove the blueprint function later)
/getRecipes can return recipes twice if 2 schematics unlocks the same recipe, now a recipe is unique in the list