### PR TITLE
Reduced log spam due to nullptr

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/Endpoints/Factory/Support.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/Endpoints/Factory/Support.cpp
@@ -52,7 +52,12 @@ void USupport::getHubTerminal(UObject* WorldContext, FRequestData RequestData, T
 
 		TSharedPtr<FJsonObject> JHubTerminal = CreateBuildableBaseJsonObject(HubTerminal);
 		TSubclassOf<UFGSchematic> ActiveSchematic = SchematicManager->GetActiveSchematic();
-		FString SchematicName = UFGSchematic::GetSchematicDisplayName(ActiveSchematic).ToString();
+
+		FString SchematicName = TEXT("No Active Milestone");
+
+		if (ActiveSchematic != nullptr) {
+			SchematicName = UFGSchematic::GetSchematicDisplayName(ActiveSchematic).ToString();
+		}
 		
 		TArray<TSharedPtr<FJsonValue>> JRecipeArray;
 		TSharedPtr<FJsonObject> JSchematic;

--- a/Source/FicsitRemoteMonitoring/Private/Endpoints/World/Research.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/Endpoints/World/Research.cpp
@@ -112,13 +112,22 @@ void UResearch::getResearchTrees(UObject* WorldContext, FRequestData RequestData
 			}
 
 			// test 1
-			auto SchematicCategory = UFGSchematic::GetSchematicCategory(NodeSchematic);
+			
+			FString Category = TEXT("N/A");
+			FString Schematic = TEXT("N/A");
 
+			if (IsValid(NodeSchematic))
+			{
+				auto SchematicCategory = UFGSchematic::GetSchematicCategory(NodeSchematic);
+				Category = UFGSchematicCategory::GetCategoryName(SchematicCategory).ToString();
+				Schematic = UFGSchematic::GetSchematicDisplayName(NodeSchematic).ToString();
+			}
+			
 			// end result
-			JResearchNode->Values.Add("Name", MakeShared<FJsonValueString>(UFGSchematic::GetSchematicDisplayName(NodeSchematic).ToString()));
+			JResearchNode->Values.Add("Name", MakeShared<FJsonValueString>(Schematic));
 			JResearchNode->Values.Add("ClassName", MakeShared<FJsonValueString>(ResearchNode->GetName()));
 			JResearchNode->Values.Add("Description", MakeShared<FJsonValueString>(UFGSchematic::GetSchematicDescription(NodeSchematic).ToString()));
-			JResearchNode->Values.Add("Category", MakeShared<FJsonValueString>(UFGSchematicCategory::GetCategoryName(SchematicCategory).ToString()));
+			JResearchNode->Values.Add("Category", MakeShared<FJsonValueString>(Category));
 			JResearchNode->Values.Add("State", MakeShared<FJsonValueString>(State));
 			JResearchNode->Values.Add("TechTier", MakeShared<FJsonValueNumber>(UFGSchematic::GetTechTier(NodeSchematic)));
 			JResearchNode->Values.Add("TimeToComplete", MakeShared<FJsonValueNumber>(UFGSchematic::GetTimeToComplete(NodeSchematic)));
@@ -251,9 +260,15 @@ TSharedPtr<FJsonObject> UResearch::getRecipe(UObject* WorldContext, TSubclassOf<
 		JProducedInArray.Add(MakeShared<FJsonValueString>(UKismetSystemLibrary::GetDisplayName(Workshop)));
 	}
 
+	FString Category = "N/A";
+	
+	if (IsValid(UFGRecipe::GetCategory(Recipe))) {
+		Category = UFGItemCategory::GetCategoryName(UFGRecipe::GetCategory(Recipe)).ToString();
+	}
+
 	JRecipe->Values.Add("Name", MakeShared<FJsonValueString>(UFGRecipe::GetRecipeName(Recipe).ToString()));
 	JRecipe->Values.Add("ClassName", MakeShared<FJsonValueString>(UKismetSystemLibrary::GetClassDisplayName(Recipe)));
-	JRecipe->Values.Add("Category", MakeShared<FJsonValueString>(UFGItemCategory::GetCategoryName(UFGRecipe::GetCategory(Recipe)).ToString()));
+	JRecipe->Values.Add("Category", MakeShared<FJsonValueString>(Category));
 	JRecipe->Values.Add("Events", MakeShared<FJsonValueArray>(JEventsArray));
 	JRecipe->Values.Add("Ingredients", MakeShared<FJsonValueArray>(JIngredientArray));
 	JRecipe->Values.Add("Products", MakeShared<FJsonValueArray>(JProductArray));


### PR DESCRIPTION
Example:

LogGame: Warning: FGCategory::GetCategoryName: class was nullpeter.
LogGame: Warning: FGCategory::GetCategoryName: class was nullpeter.