### PR TITLE
getSessionInfo - IsPaused

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/Endpoints/World/Session.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/Endpoints/World/Session.cpp
@@ -22,6 +22,7 @@ void USession::getSessionInfo(UObject* WorldContext, FRequestData RequestData, T
 
 	TSharedPtr<FJsonObject> JSessionInfo = MakeShared<FJsonObject>();
 	JSessionInfo->Values.Add("SessionName", MakeShared<FJsonValueString>(GameState->GetSessionName()));
+	JSessionInfo->Values.Add("IsPaused", MakeShared<FJsonValueBoolean>(WorldContext->GetWorld()->IsPaused()));
 	JSessionInfo->Values.Add("DayLength", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetDayLength()));
 	JSessionInfo->Values.Add("NightLength", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetNightLength()));
 	JSessionInfo->Values.Add("PassedDays", MakeShared<FJsonValueNumber>(TimeOfDaySubSystem->GetPassedDays()));


### PR DESCRIPTION
Determines if Dedi is paused or not, client will return true as the game is required be loaded and running to call endpoint, thus will always return true, unless another mod pauses
