### PR TITLE
fix: potential fix for rare websocket crash while switching save games

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/Commands/multi.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/Commands/multi.cpp
@@ -89,17 +89,16 @@ FChatReturn AFRMCommand::RemoteMonitoringCommand(UObject* WorldContext, UCommand
 			auto config = FConfig_HTTPStruct::GetActiveConfig(WorldContext);
 			int32 Port = config.HTTP_Port;
 			
-			ModSubsystem->StartWebSocketServer();
+			UE_LOG(LogHttpServer, Log, TEXT("Chat Command: Starting HTTP Service. Port: %d"), Port);
+			ModSubsystem->StartWebSocketServer(true);
 
 			ChatReturn.Chat = FString(TEXT("HTTP Service Initiated on Port: " + FString::FromInt(Port)));
 			ChatReturn.Color = FLinearColor::Green;
 			ChatReturn.Status = EExecutionStatus::COMPLETED;
-
-			UE_LOG(LogHttpServer, Log, TEXT("HTTP Service started. Port: %d"), Port);
 		}
 		else if (arg1 == "stop") {
+			UE_LOG(LogHttpServer, Log, TEXT("Chat Command: Stopping HTTP Service."));
 			ModSubsystem->StopWebSocketServer();
-			UE_LOG(LogHttpServer, Log, TEXT("Stopping HTTP Service."));
 
 			ChatReturn.Chat = TEXT("Stopping HTTP Service.");
 			ChatReturn.Color = FLinearColor::White;

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -108,7 +108,7 @@ void AFicsitRemoteMonitoring::StartWebSocketPushDataLoop()
 	Async(EAsyncExecution::Thread, [this, HttpConfig]()
 	{
 		UE_LOGFMT(LogHttpServer, Log, "Starting PushUpdatedData loop");
-		while (SocketRunning)
+		while (SocketRunning && !bShouldStop)
 		{
 			PushUpdatedData();
 			FPlatformProcess::Sleep(HttpConfig.WebSocketPushCycle);
@@ -119,6 +119,8 @@ void AFicsitRemoteMonitoring::StartWebSocketPushDataLoop()
 
 void AFicsitRemoteMonitoring::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
+	bShouldStop = true;
+
 	// Ensure the server is stopped during normal gameplay exit
 	StopWebSocketServer();
 	Super::EndPlay(EndPlayReason);

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -85,7 +85,7 @@ void AFicsitRemoteMonitoring::BeginPlay()
 
 	Async(EAsyncExecution::Thread, [this, HttpConfig]()
 	{
-		while (!bShouldStop)
+		while (SocketRunning)
 		{
 			FPlatformProcess::Sleep(HttpConfig.WebSocketPushCycle);
 			PushUpdatedData();
@@ -112,9 +112,6 @@ FString AFicsitRemoteMonitoring::GenerateAuthToken(const int32 Length)
 
 void AFicsitRemoteMonitoring::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-    // clear the timer
-	bShouldStop = true;
-
 	// Ensure the server is stopped during normal gameplay exit
 	StopWebSocketServer();
 	Super::EndPlay(EndPlayReason);

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -102,6 +102,7 @@ private:
 	TFuture<void> WebServer;
 	
 	bool JSONDebugMode = false;
+	bool bShouldStop = false;
 	
 	friend class UFGPowerCircuitGroup;
 

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -102,7 +102,6 @@ private:
 	TFuture<void> WebServer;
 	
 	bool JSONDebugMode = false;
-	bool bShouldStop = false;
 	
 	friend class UFGPowerCircuitGroup;
 

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -191,6 +191,7 @@ protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	FString GenerateAuthToken(int32 Length);
+	void StartWebSocketPushDataLoop();
 
 public:
 

--- a/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
+++ b/Source/FicsitRemoteMonitoring/Public/FicsitRemoteMonitoring.h
@@ -103,6 +103,7 @@ private:
 	
 	bool JSONDebugMode = false;
 	bool bShouldStop = false;
+	bool bHasRunningPushDataLoop = false;
 	
 	friend class UFGPowerCircuitGroup;
 
@@ -166,7 +167,7 @@ public:
 	void InitAPIRegistry();
 	void InitOutageNotification();
 
-	void StartWebSocketServer();
+	void StartWebSocketServer(bool bSkipIfRunning = false);
 	void StopWebSocketServer();
 
 	void OnClientDisconnected(uWS::WebSocket<false, true, FWebSocketUserData>* ws, int code, std::string_view message);


### PR DESCRIPTION
sometime if you switching a save game you get this crash
this should fix it too

- websocket pushdata loop will created after the websocket server is started
- loop will stopped if the webserver will be stopped (e.g. with the chat command)
- prevent trying to start the webserver every 3 seconds if it is already running (for chat command)

```
FactoryGameSteam_FicsitRemoteMonitoring_Win64_Shipping!AFicsitRemoteMonitoring::PushUpdatedData() [M:\GameDev\Satisfactory\SatisfactoryModLoader\Mods\FicsitRemoteMonitoring\Source\FicsitRemoteMonitoring\Private\FicsitRemoteMonitoring.cpp:508]
FactoryGameSteam_FicsitRemoteMonitoring_Win64_Shipping!UE::Core::Private::Function::TFunctionRefCaller<`AFicsitRemoteMonitoring::BeginPlay'::`2'::<lambda_1>,void __cdecl(void)>::Call() [M:\GameDev\Satisfactory\UnrealEngine-CSS\Engine\Source\Runtime\Core\Public\Templates\Function.h:479]
FactoryGameSteam_FicsitRemoteMonitoring_Win64_Shipping!TAsyncRunnable<void>::Run() [M:\GameDev\Satisfactory\UnrealEngine-CSS\Engine\Source\Runtime\Core\Public\Async\Async.h:457]
```