### PR TITLE
fix: Use GameThread when UE is garbage collecting/serializing

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -959,7 +959,7 @@ FCallEndpointResponse AFicsitRemoteMonitoring::CallEndpoint(UObject* WorldContex
         Response.bUseFirstObject = EndpointInfo.bUseFirstObject;
 
         try {
-            if (EndpointInfo.bRequireGameThread && RequestData.Interface != EInterfaceType::Server) {
+            if ((EndpointInfo.bRequireGameThread || IsGarbageCollecting()) && !IsInGameThread()) {
                 FThreadSafeBool bAllocationComplete = false;
                 AsyncTask(ENamedThreads::GameThread, [&EndpointInfo, WorldContext, RequestData, &JsonArray, &bAllocationComplete, &ErrorCode, &bSuccess]() {
 					//if (SocketListener && EndpointInfo.FunctionPtr)


### PR DESCRIPTION
Uses Game Thread when UE is Garbage Collecting

Test ran for 20+ hours on a Arch Linux and Ubuntu Dedi. Attached logs from both

[FactoryGame_Arch.log](https://github.com/user-attachments/files/20793586/FactoryGame_Arch.log)
[FactoryGame_Ubuntu.log](https://github.com/user-attachments/files/20793587/FactoryGame_Ubuntu.log)

Ought to solve #80, #83, #126, and #173