### PR TITLE
CallEndpoint: Stop API Calls while WorldContext is not valid

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -948,6 +948,15 @@ FCallEndpointResponse AFicsitRemoteMonitoring::CallEndpoint(UObject* WorldContex
 	TArray<FString> AvailableMethods;
     bool bEndpointFound = false;
 
+	if (!IsValid(WorldContext))
+	{
+		UE_LOG(LogHttpServer, Warning, TEXT("Blocked API call: World not ready."));
+		ErrorCode = 503;
+		AddErrorJson(JsonArray, TEXT("Blocked API call: World not ready."));
+		Response.JsonValues = JsonArray;
+		return Response;
+	}
+
     for (FAPIEndpoint& EndpointInfo : APIEndpoints)
     {
 	    if (EndpointInfo.APIName != InEndpoint) continue;

--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -948,7 +948,7 @@ FCallEndpointResponse AFicsitRemoteMonitoring::CallEndpoint(UObject* WorldContex
 	TArray<FString> AvailableMethods;
     bool bEndpointFound = false;
 
-	if (!IsValid(WorldContext))
+	if (!IsValid(WorldContext) || !IsValid(WorldContext->GetWorld()))
 	{
 		UE_LOG(LogHttpServer, Warning, TEXT("Blocked API call: World not ready."));
 		ErrorCode = 503;


### PR DESCRIPTION
If the world context is not valid, usually during the time that uWS thread is active, but the world context/world is not fully loaded, then do not call for endpoint and return a 503.

This either complements or makes obsolete PR #232. Discussion necessary with @Th3Fanbus and @derpierre65 for best path forward.