### PR TITLE
getExplorer might not need to request game thread

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -717,7 +717,7 @@ void AFicsitRemoteMonitoring::InitAPIRegistry()
 	RegisterEndpoint(FAPIEndpoint("GET", "getDropPod", &UResources::getDropPod).RequiresGameThread());
 	RegisterEndpoint(FAPIEndpoint("GET", "getEncoder", &UFactoryLibrary::getEncoder));
 	RegisterEndpoint(FAPIEndpoint("GET", "getExplorationSink", &USession::getExplorationSink));
-	RegisterEndpoint(FAPIEndpoint("GET", "getExplorer", &UVehicles::getExplorer).RequiresGameThread());
+	RegisterEndpoint(FAPIEndpoint("GET", "getExplorer", &UVehicles::getExplorer));
 	RegisterEndpoint(FAPIEndpoint("GET", "getExtractor", &UResources::getExtractor));
 	RegisterEndpoint(FAPIEndpoint("GET", "getFactoryCart", &UVehicles::getFactoryCart));
 	RegisterEndpoint(FAPIEndpoint("GET", "getFoundry", &UFactoryLibrary::getFoundry));


### PR DESCRIPTION
Other vehicles do not use it, so getExplorer might not need it either.