### PR TITLE
fix: dead player name

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/RemoteMonitoringLibrary.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/RemoteMonitoringLibrary.cpp
@@ -659,7 +659,7 @@ FString URemoteMonitoringLibrary::GetPlayerName(AFGCharacterPlayer* Character)
 
 	FString PlayerName = PlayerState->GetPlayerName();
 
-	if (!PlayerName.IsEmpty() || PlayerName != " ")
+	if (!PlayerName.IsEmpty() && PlayerName != " ")
 	{
 		return PlayerName;
 	}


### PR DESCRIPTION
Aquatically (nerd voice #2)

 — 11:05 AM
@DarthPorisius (FRM Guy) not to be a bother, but will you have fixed the name issue by the 15th?
Because it's causing some slight issues 
By slight I mean breaking
Because when I join I join as " "
Which is all well and good because it creates a class for me with the name " "
And when my name does come in
It sees me as a new person
Forgets about " " and creates a class for "Aquatic"
The problem is though that with one person, it links me and the one person
With any more than one people though
I think it'll just break

Aquatically (nerd voice #2) — 11:46 AM
No worries if not

much worries

DarthPorisius (FRM Guy) — 11:47 AM
JSON Output? Also, given current work scenario, open an issue on the Github, at the very least, one of the FRM Team can make a change and have the build server handle it for you
Aquatically (nerd voice #2) — 11:47 AM
Alright cheers

Aquatically (nerd voice #2) — 11:47 AM
yes json output
not sure how issues should be formatted
so forgive me

DarthPorisius (FRM Guy) — 11:49 AM
I mean, what's the output?
when its slightly broken?
We might be limited to what the game/engine provides\

Aquatically (nerd voice #2) — 11:51 AM
Everything identical
upon death/join the player username is returned as " "
when its slightly broken with one player
nothing
with two
i havent been able to test that as of yet
okay @DarthPorisius (FRM Guy)  i just tested it with @_nova_tech_
literal worst case scenario
Begin Cycle
0
End Cycle
Begin Cycle
0
End Cycle
Expand
message.txt
48 KB
it just keeps duplicating them
hope that helps