### PR TITLE
setEnabled to GT

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/FicsitRemoteMonitoring.cpp
@@ -792,7 +792,7 @@ void AFicsitRemoteMonitoring::InitAPIRegistry()
 
 	// post/write endpoints
 	RegisterEndpoint(FAPIEndpoint("POST", "setSwitches", &UPower::setSwitches).RequiresAuthentication().RequiresGameThread());
-	RegisterEndpoint(FAPIEndpoint("POST", "setEnabled", &UCommunication::setEnabled).RequiresAuthentication());
+	RegisterEndpoint(FAPIEndpoint("POST", "setEnabled", &UCommunication::setEnabled).RequiresAuthentication().RequiresGameThread());
 	RegisterEndpoint(FAPIEndpoint("POST", "sendChatMessage", &UCommunication::sendChatMessage).RequiresAuthentication().RequiresGameThread());
 	RegisterEndpoint(FAPIEndpoint("POST", "createPing", &UCommunication::createPing).RequiresAuthentication().RequiresGameThread());
 	RegisterEndpoint(FAPIEndpoint("POST", "setModSetting", &UCommunication::setModSetting).RequiresAuthentication().RequiresGameThread());


### PR DESCRIPTION
Possible fix only needed for non-DS Builds (#267) as `FactoryGameEGS_FicsitRemoteMonitoring_Win64_Shipping` was in error.

To resolve:
Assertion failed: IsInGameThread() || IsInSlateThread() [File:D:\BuildAgent\work\SR11_BT\UE4\Engine\Source\Runtime\SlateCore\Private\Widgets\SWidget.cpp] [Line: 1251] Slate can only be accessed from the GameThread or the SlateLoadingThread!