### PR TITLE
Introduce null checks in config Save method

### DIFF
--- a/Source/FicsitRemoteMonitoring/Public/Configs/Config_HTTPStruct.h
+++ b/Source/FicsitRemoteMonitoring/Public/Configs/Config_HTTPStruct.h
@@ -38,15 +38,22 @@ public:
 
     void Save(UWorld* World)
     {
+        if (!World) return;
+    
+        UGameInstance* GameInstance = World->GetGameInstance();
+        if (!GameInstance) return;
+        
+        UConfigManager* ConfigManager = GameInstance->GetSubsystem<UConfigManager>();
+        if (!ConfigManager) return;
+        
         FConfigId ConfigId{"FicsitRemoteMonitoring", "WebServer"};
-        UConfigManager* ConfigManager = World->GetGameInstance()->GetSubsystem<UConfigManager>();
         UConfigPropertySection* ConfigurationRootSection = ConfigManager->GetConfigurationRootSection(ConfigId);
-
+        if (!ConfigurationRootSection) return;
+        
         if (ConfigurationRootSection->SectionProperties.Contains("Authentication_Token"))
         {
             Cast<UConfigPropertyString>(ConfigurationRootSection->SectionProperties["Authentication_Token"])->Value = Authentication_Token;
         }
-
         ConfigManager->MarkConfigurationDirty(ConfigId);
     }
 };

--- a/Source/FicsitRemoteMonitoring/Public/Configs/Config_HTTPStruct.h
+++ b/Source/FicsitRemoteMonitoring/Public/Configs/Config_HTTPStruct.h
@@ -39,21 +39,28 @@ public:
     void Save(UWorld* World)
     {
         if (!World) return;
-    
+
         UGameInstance* GameInstance = World->GetGameInstance();
         if (!GameInstance) return;
-        
+
         UConfigManager* ConfigManager = GameInstance->GetSubsystem<UConfigManager>();
         if (!ConfigManager) return;
-        
-        FConfigId ConfigId{"FicsitRemoteMonitoring", "WebServer"};
-        UConfigPropertySection* ConfigurationRootSection = ConfigManager->GetConfigurationRootSection(ConfigId);
-        if (!ConfigurationRootSection) return;
-        
-        if (ConfigurationRootSection->SectionProperties.Contains("Authentication_Token"))
-        {
-            Cast<UConfigPropertyString>(ConfigurationRootSection->SectionProperties["Authentication_Token"])->Value = Authentication_Token;
-        }
+
+        const FConfigId ConfigId{ "FicsitRemoteMonitoring", "WebServer" };
+        UConfigPropertySection* Section =
+            ConfigManager->GetConfigurationRootSection(ConfigId);
+
+        if (!Section) return;
+
+        UConfigProperty* Property =
+            Section->SectionProperties.FindRef("Authentication_Token");
+
+        UConfigPropertyString* StringProp =
+            Cast<UConfigPropertyString>(Property);
+
+        if (!StringProp) return;
+
+        StringProp->Value = Authentication_Token;
         ConfigManager->MarkConfigurationDirty(ConfigId);
     }
 };


### PR DESCRIPTION
Refactor Save method to check for valid World and GameInstance before accessing ConfigManager.