### PR TITLE
Fix SIGSEGV in /frm config on dedicated servers

### DIFF
--- a/Source/FicsitRemoteMonitoring/Private/Commands/multi.cpp
+++ b/Source/FicsitRemoteMonitoring/Private/Commands/multi.cpp
@@ -134,8 +134,14 @@ FChatReturn AFRMCommand::RemoteMonitoringCommand(UObject* WorldContext, UCommand
 		FString arg1 = Arguments[1].ToLower();
 		FString arg2 = Arguments[2].ToLower();
 	
-		AFGPlayerController* PlayerController = Cast<AFGPlayerController>(Sender->GetPlayer()->GetControlledCharacter()->GetLocalViewingPlayerController());
-		EPrivilegeLevel PrivilegeLevel = PlayerController->GetDSPrivilegeLevel();
+		// UCommandSender::GetPlayer() already returns the sender's server-side AFGPlayerController.
+		// The previous GetControlledCharacter()->GetLocalViewingPlayerController() detour is null on a
+		// dedicated server (no local client) and crashed (SIGSEGV) on ANY /frm config. A null controller
+		// here means a non-player/console sender, which we treat as trusted.
+		AFGPlayerController* PlayerController = Sender ? Sender->GetPlayer() : nullptr;
+		// A null (console/non-player) sender is trusted -> InitialAdmin so the check below passes and
+		// short-circuits before ever calling GetNetMode() on the null controller.
+		const EPrivilegeLevel PrivilegeLevel = IsValid(PlayerController) ? PlayerController->GetDSPrivilegeLevel() : EPrivilegeLevel::InitialAdmin;
 		
 		if (PrivilegeLevel != EPrivilegeLevel::Administrator &&
 			PrivilegeLevel != EPrivilegeLevel::InitialAdmin &&
@@ -145,7 +151,8 @@ FChatReturn AFRMCommand::RemoteMonitoringCommand(UObject* WorldContext, UCommand
 			ChatReturn.Chat = FString(TEXT("Insufficient Permissions to set " + arg1 + " to " +arg2));
 			ChatReturn.Color = FLinearColor::Red;
 			ChatReturn.Status = EExecutionStatus::COMPLETED;
-		}		
+			return ChatReturn;
+		}
 
 		if (UFRMConfigManager::SetConfigFromInput(arg1, arg2))
 		{


### PR DESCRIPTION
## Problem

`/frm config <setting> <value>` crashes a **dedicated server** with a SIGSEGV on *any* invocation (any setting, any value).

The command resolves the calling player's controller with:

```cpp
AFGPlayerController* PlayerController = Cast<AFGPlayerController>(
    Sender->GetPlayer()->GetControlledCharacter()->GetLocalViewingPlayerController());
EPrivilegeLevel PrivilegeLevel = PlayerController->GetDSPrivilegeLevel();
```

On a dedicated server there is no *local viewing* player controller, so `GetLocalViewingPlayerController()` returns null, the `Cast` yields null, and `GetDSPrivilegeLevel()` (a `FORCEINLINE` member read) dereferences it → `SIGSEGV: invalid attempt to read memory at address 0x...09d0`.

Reproduction: run `/frm config uWS.Port 8080` (or any key) from an admin client on a dedicated server → server crashes.

## Fix

- `UCommandSender::GetPlayer()` already returns the sender's server-side `AFGPlayerController`, so use it directly instead of the `GetControlledCharacter()->GetLocalViewingPlayerController()` detour.
- Null-guard the controller: a null (console / non-player) sender is treated as trusted, and the privilege check short-circuits before `GetNetMode()` is ever called on a null pointer.
- Add the missing early `return` so a player *without* sufficient privileges no longer falls through and applies the setting anyway.

One file changed, no behavioral change for authorized listen-server/standalone/admin callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)